### PR TITLE
fix: load custom fonts via FontFace API for xterm.js Canvas rendering

### DIFF
--- a/docs/superpowers/plans/2026-04-08-custom-font-loading.md
+++ b/docs/superpowers/plans/2026-04-08-custom-font-loading.md
@@ -1,0 +1,511 @@
+# Custom Font Loading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Load user-installed fonts into the browser's font system via Tauri IPC so the xterm.js CanvasAddon can render them.
+
+**Architecture:** Rust uses macOS CoreText API to resolve a font family name to file paths and reads the font bytes. JS receives the bytes via IPC, creates `FontFace` objects from the ArrayBuffer, and adds them to `document.fonts`. Once loaded, fonts are available to Canvas 2D and xterm.js renders them correctly.
+
+**Tech Stack:** Rust (core-text crate, CoreText/CoreFoundation), TypeScript (FontFace API), Tauri v2 IPC
+
+---
+
+### Task 1: Rust Font Resolution Module
+
+**Files:**
+- Create: `src-tauri/src/fonts.rs`
+- Modify: `src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Add core-text dependency to Cargo.toml**
+
+Add `core-text` and `core-foundation` after the existing `notify` dependency in `src-tauri/Cargo.toml`:
+
+```toml
+core-text = "21"
+core-foundation = "0.10"
+```
+
+- [ ] **Step 2: Create `src-tauri/src/fonts.rs`**
+
+```rust
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FontFile {
+    /// Raw font file bytes (TTF/OTF)
+    pub data: Vec<u8>,
+    /// Font style, e.g. "Regular", "Bold", "Italic", "Bold Italic"
+    pub style: String,
+}
+
+/// Resolve a font family name to its on-disk font files using the macOS CoreText API.
+/// Returns an empty Vec on non-macOS platforms or if the family is not found.
+#[cfg(target_os = "macos")]
+pub fn resolve_font_files_for_family(family_name: &str) -> Vec<FontFile> {
+    use core_foundation::base::TCFType;
+    use core_foundation::string::CFString;
+    use core_text::font_descriptor::{self, CTFontDescriptor};
+
+    let cf_family = CFString::new(family_name);
+    let mandatory_attrs =
+        core_foundation::dictionary::CFDictionary::from_CFType_pairs(&[(
+            CFString::from_static_string(font_descriptor::kCTFontFamilyNameAttribute),
+            cf_family.as_CFType(),
+        )]);
+
+    let desc = font_descriptor::new_from_attributes(&mandatory_attrs);
+    let matching = desc.create_matching_font_descriptors();
+
+    let Some(descriptors) = matching else {
+        return Vec::new();
+    };
+
+    let mut result = Vec::new();
+    for i in 0..descriptors.len() {
+        let desc: CTFontDescriptor = unsafe {
+            let ptr = core_foundation::array::CFArray::get_unchecked(
+                &descriptors, i,
+            );
+            TCFType::wrap_under_get_rule(ptr)
+        };
+
+        // Get the file URL for this font descriptor
+        let url = unsafe {
+            let key = CFString::from_static_string(
+                font_descriptor::kCTFontURLAttribute,
+            );
+            let val = desc.attribute(&key);
+            if val.is_none() {
+                continue;
+            }
+            let url_ref: core_foundation::url::CFURL =
+                TCFType::wrap_under_get_rule(
+                    val.unwrap().as_CFTypeRef() as core_foundation::url::CFURLRef,
+                );
+            url_ref
+        };
+
+        let Some(path) = url.to_path() else {
+            continue;
+        };
+
+        // Read font file bytes
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+
+        // Get the style name (Regular, Bold, etc.)
+        let style = {
+            let key = CFString::from_static_string(
+                font_descriptor::kCTFontStyleNameAttribute,
+            );
+            desc.attribute(&key)
+                .and_then(|val| unsafe {
+                    let cf_str: CFString =
+                        TCFType::wrap_under_get_rule(val.as_CFTypeRef() as _);
+                    Some(cf_str.to_string())
+                })
+                .unwrap_or_else(|| "Regular".to_string())
+        };
+
+        result.push(FontFile { data, style });
+    }
+
+    result
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn resolve_font_files_for_family(_family_name: &str) -> Vec<FontFile> {
+    Vec::new()
+}
+```
+
+- [ ] **Step 3: Verify Rust compiles**
+
+Run from `src-tauri/`:
+```bash
+cargo check
+```
+Expected: compiles without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/fonts.rs src-tauri/Cargo.toml
+git commit -m "feat: add CoreText font resolution module"
+```
+
+---
+
+### Task 2: Tauri Command + IPC Wiring
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs` (add `mod fonts;`)
+- Modify: `src-tauri/src/commands.rs` (add `resolve_font_files` command)
+- Modify: `src/lib/types.ts` (add `FontFile` type)
+- Modify: `src/lib/tauri.ts` (add IPC wrapper)
+
+- [ ] **Step 1: Add `mod fonts;` to `src-tauri/src/lib.rs`**
+
+Add after the existing module declarations (after line 7):
+
+```rust
+mod fonts;
+```
+
+- [ ] **Step 2: Add the Tauri command to `src-tauri/src/commands.rs`**
+
+Add this import at the top (after the existing `use crate::` imports around line 14):
+
+```rust
+use crate::fonts;
+```
+
+Add this command at the end of the file (before the closing of the file):
+
+```rust
+// ── Font commands ───────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn resolve_font_files(family_name: &str) -> Vec<fonts::FontFile> {
+    fonts::resolve_font_files_for_family(family_name)
+}
+```
+
+- [ ] **Step 3: Register the command in `src-tauri/src/lib.rs`**
+
+Add `commands::resolve_font_files,` to the `tauri::generate_handler![]` list. Add it after `commands::open_url,` (line 128):
+
+```rust
+            commands::open_url,
+            commands::resolve_font_files,
+```
+
+- [ ] **Step 4: Add `FontFile` type to `src/lib/types.ts`**
+
+Add after the `TerminalSettings` interface (after line 47):
+
+```typescript
+export interface FontFile {
+  data: number[];
+  style: string;
+}
+```
+
+- [ ] **Step 5: Add IPC wrapper to `src/lib/tauri.ts`**
+
+Add the `FontFile` import to the existing imports (add after `PortInfo` on line 20):
+
+```typescript
+  FontFile,
+```
+
+Add the function at the end of the file (or in a `// ── Font commands ──` section):
+
+```typescript
+// ── Font commands ───────────────────────────────────────────────────
+
+export function resolveFontFiles(familyName: string): Promise<FontFile[]> {
+  return invoke("resolve_font_files", { familyName });
+}
+```
+
+- [ ] **Step 6: Verify Rust compiles and TypeScript compiles**
+
+```bash
+cd src-tauri && cargo check
+cd .. && pnpm tsc --noEmit
+```
+
+Expected: both compile without errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/lib.rs src-tauri/src/commands.rs src/lib/types.ts src/lib/tauri.ts
+git commit -m "feat: add resolve_font_files Tauri command and IPC wiring"
+```
+
+---
+
+### Task 3: TypeScript Font Loader
+
+**Files:**
+- Create: `src/lib/fontLoader.ts`
+
+- [ ] **Step 1: Create `src/lib/fontLoader.ts`**
+
+```typescript
+import { resolveFontFiles } from "./tauri";
+import { FONT_OPTIONS } from "./terminalConfig";
+
+/** Font family names that are already loaded or don't need loading. */
+const SKIP_FAMILIES = new Set([
+  ...FONT_OPTIONS.map((f) => f.label),
+  "MesloLGS NF",
+  "Menlo",
+  "Monaco",
+  "Courier New",
+  "monospace",
+  "ui-monospace",
+]);
+
+/** Tracks which font families have already been loaded in this session. */
+const loadedFamilies = new Set<string>();
+
+/**
+ * Extract the primary (first) bare font name from a CSS font-family string.
+ * e.g. "'MonoLisaNikos Nerd Font', monospace" → "MonoLisaNikos Nerd Font"
+ */
+function extractPrimaryFamily(fontFamily: string): string {
+  const first = fontFamily.split(",")[0].trim();
+  // Strip surrounding quotes
+  if (
+    (first.startsWith("'") && first.endsWith("'")) ||
+    (first.startsWith('"') && first.endsWith('"'))
+  ) {
+    return first.slice(1, -1);
+  }
+  return first;
+}
+
+/**
+ * Map a FontFace style string (e.g. "Bold Italic") to CSS font-style
+ * and font-weight descriptor values.
+ */
+function parseFontStyle(style: string): { weight: string; style: string } {
+  const lower = style.toLowerCase();
+  const isBold = lower.includes("bold");
+  const isItalic = lower.includes("italic") || lower.includes("oblique");
+  return {
+    weight: isBold ? "bold" : "normal",
+    style: isItalic ? "italic" : "normal",
+  };
+}
+
+/**
+ * Load a custom font into the browser's font system so it is available
+ * to Canvas 2D (and therefore to xterm.js CanvasAddon).
+ *
+ * Resolves the font family name to on-disk font files via Tauri IPC,
+ * then creates FontFace objects from the binary data and adds them
+ * to document.fonts.
+ *
+ * @returns true if at least one font face was loaded, false otherwise.
+ */
+export async function loadCustomFont(fontFamily: string): Promise<boolean> {
+  const familyName = extractPrimaryFamily(fontFamily);
+
+  // Skip system/preset/bundled fonts — they're already available
+  if (SKIP_FAMILIES.has(familyName)) return false;
+
+  // Skip if already loaded in this session
+  if (loadedFamilies.has(familyName)) return true;
+
+  try {
+    const fontFiles = await resolveFontFiles(familyName);
+    if (fontFiles.length === 0) return false;
+
+    let loaded = false;
+    for (const file of fontFiles) {
+      try {
+        const buffer = new Uint8Array(file.data).buffer;
+        const { weight, style } = parseFontStyle(file.style);
+        const face = new FontFace(familyName, buffer, { weight, style });
+        await face.load();
+        document.fonts.add(face);
+        loaded = true;
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.error(
+            `Failed to load font face "${familyName}" (${file.style}):`,
+            e,
+          );
+        }
+      }
+    }
+
+    if (loaded) {
+      loadedFamilies.add(familyName);
+    }
+    return loaded;
+  } catch (e) {
+    if (import.meta.env.DEV) {
+      console.error(`Failed to resolve font files for "${familyName}":`, e);
+    }
+    return false;
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/fontLoader.ts
+git commit -m "feat: add font loader utility for custom font loading via FontFace API"
+```
+
+---
+
+### Task 4: Integrate Font Loading into Settings Store
+
+**Files:**
+- Modify: `src/stores/useTerminalSettingsStore.ts`
+
+- [ ] **Step 1: Add loadCustomFont import**
+
+Add to the imports at the top of `src/stores/useTerminalSettingsStore.ts` (after line 4):
+
+```typescript
+import { loadCustomFont } from "../lib/fontLoader";
+```
+
+- [ ] **Step 2: Update `loadSettings` to load custom font on startup**
+
+Replace the `loadSettings` method (lines 31-47) with:
+
+```typescript
+  loadSettings: async () => {
+    try {
+      const settings = await getTerminalSettings();
+      const normalizedSettings = {
+        ...settings,
+        fontFamily: normalizeTerminalFontFamily(settings.fontFamily),
+      };
+      // Load custom font into browser before applying to terminals
+      await loadCustomFont(normalizedSettings.fontFamily);
+      set({ settings: normalizedSettings, hasLoaded: true, error: null });
+      applyTerminalSettings(normalizedSettings);
+      if (normalizedSettings.fontFamily !== settings.fontFamily) {
+        saveTerminalSettings(normalizedSettings).catch((error) => {
+          set({ error: String(error) });
+        });
+      }
+    } catch (error) {
+      set({ settings: DEFAULT_SETTINGS, hasLoaded: true, error: String(error) });
+    }
+  },
+```
+
+- [ ] **Step 3: Update `updateSettings` to load custom font before applying**
+
+Replace the `updateSettings` method (lines 50-70) with:
+
+```typescript
+  updateSettings: async (partial) => {
+    const prev = get().settings;
+    const next = {
+      ...prev,
+      ...partial,
+      ...(partial.fontFamily !== undefined
+        ? { fontFamily: normalizeTerminalFontFamily(partial.fontFamily) }
+        : {}),
+    };
+    // Load custom font into browser before applying to terminals
+    await loadCustomFont(next.fontFamily);
+    // Optimistic update
+    set({ settings: next, isSaving: true, error: null });
+    applyTerminalSettings(next);
+    try {
+      await saveTerminalSettings(next);
+      set({ isSaving: false });
+    } catch (error) {
+      // Rollback
+      set({ settings: prev, isSaving: false, error: String(error) });
+      applyTerminalSettings(prev);
+    }
+  },
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: compiles without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stores/useTerminalSettingsStore.ts
+git commit -m "feat: load custom fonts via FontFace API before applying terminal settings"
+```
+
+---
+
+### Task 5: Remove Diagnostic Logging
+
+**Files:**
+- Modify: `src/components/terminal/terminalTheme.ts` (remove `[font-diag]` logging)
+- Modify: `src/components/terminal/TerminalView.tsx` (remove `[font-diag]` logging)
+
+- [ ] **Step 1: Remove debug logging from `terminalTheme.ts`**
+
+Remove the entire `if (import.meta.env.DEV)` block that contains `[font-diag applySettings]` log statements from the `applyTerminalSettings` function. Keep the `clearTextureAtlas()` call and everything else.
+
+- [ ] **Step 2: Remove debug logging from `TerminalView.tsx`**
+
+Remove the entire `if (import.meta.env.DEV)` block that contains `[font-diag attachTerminal]` log statements from the `attachTerminal` function. Keep the font change detection, settings re-application, and `clearTextureAtlas()` call.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: compiles without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/terminal/terminalTheme.ts src/components/terminal/TerminalView.tsx
+git commit -m "chore: remove font diagnostic logging"
+```
+
+---
+
+### Task 6: Manual Verification
+
+- [ ] **Step 1: Build and run the app**
+
+```bash
+pnpm tauri dev
+```
+
+- [ ] **Step 2: Test custom font**
+
+1. Open Settings (gear icon)
+2. In the Terminal section, type "MonoLisaNikos Nerd Font" in the custom font input
+3. Press Enter or click outside the input (blur)
+4. Close Settings
+5. **Verify**: Terminal text should render in MonoLisaNikos Nerd Font, not monospace
+
+- [ ] **Step 3: Test preset font switching**
+
+1. Open Settings
+2. Click "MesloLGS Nerd Font" preset button
+3. Close Settings
+4. **Verify**: Terminal renders in MesloLGS NF
+
+- [ ] **Step 4: Test persistence**
+
+1. Set custom font to "MonoLisaNikos Nerd Font"
+2. Close and restart the app (`pnpm tauri dev`)
+3. **Verify**: Terminal renders in the custom font on startup (loadSettings loads it)
+
+- [ ] **Step 5: Test non-existent font**
+
+1. Type "NonExistentFont" in the custom font input
+2. Press Enter
+3. Close Settings
+4. **Verify**: Terminal falls back to monospace gracefully, no errors in console

--- a/docs/superpowers/specs/2026-04-08-custom-font-loading-design.md
+++ b/docs/superpowers/specs/2026-04-08-custom-font-loading-design.md
@@ -1,0 +1,93 @@
+# Custom Font Loading via CoreText + FontFace API
+
+## Problem
+
+The Canvas 2D API in Tauri's WKWebView cannot access user-installed fonts from `~/Library/Fonts/`. The xterm.js CanvasAddon renders all terminal text using `ctx.fillText()` on HTMLCanvasElement, so custom fonts never render — they silently fall back to the generic monospace font. System fonts (Menlo, Monaco) work because they're in `/System/Library/Fonts/`. The bundled MesloLGS NF works because it's loaded via `@font-face` with a `url()` pointing to a Vite-bundled asset.
+
+## Solution
+
+Load custom font files via Tauri IPC: Rust uses macOS CoreText API to resolve a font family name to file paths, reads the font bytes, and returns them to JS. The frontend creates `FontFace` objects from the ArrayBuffer data and adds them to `document.fonts`. Fonts loaded via the FontFace API with binary data are available to Canvas 2D in all browsers including WKWebView.
+
+## Architecture
+
+```
+User types "MonoLisaNikos Nerd Font" in settings → onBlur
+  → normalizeTerminalFontFamily() → "'MonoLisaNikos Nerd Font', monospace"
+  → updateTermSettings({ fontFamily: ... })
+  → Zustand store saves + calls applyTerminalSettings()
+  → NEW: loadCustomFont("MonoLisaNikos Nerd Font")
+    → Tauri IPC: resolve_font_files("MonoLisaNikos Nerd Font")
+    → Rust: CoreText API → finds font file paths → reads bytes
+    → Returns Vec<FontFileData> to JS
+    → JS: new FontFace(name, bytes) → document.fonts.add()
+    → Font now available to Canvas 2D
+  → term.options.fontFamily set → clearTextureAtlas() → refresh
+```
+
+## Components
+
+### Rust: Font Resolution (`src-tauri/src/fonts.rs`)
+
+- New Tauri command: `resolve_font_files(family_name: String) -> Vec<FontFile>`
+- Uses the `core-text` crate (or `core-foundation` + `core-text` bindings) to:
+  1. Create a font descriptor matching the given family name
+  2. Find all font descriptors in the system that match
+  3. Get the file URL for each matched descriptor
+  4. Read the font file bytes from disk
+- Returns a `Vec<FontFile>` where each entry contains:
+  - `data: Vec<u8>` — the raw font file bytes
+  - `style: String` — e.g. "Regular", "Bold", "Italic", "BoldItalic"
+- Register the command in `src-tauri/src/lib.rs`
+- Platform-specific: macOS only for now. On other platforms, the command returns an empty Vec (graceful degradation).
+
+### TypeScript: Font Loader (`src/lib/fontLoader.ts`)
+
+- `loadCustomFont(fontFamily: string): Promise<boolean>` — main entry point
+  - Extracts the bare font name from a CSS font-family string (strips single quotes, removes fallback fonts after commas)
+  - Checks if font is already loaded (tracked in a module-level `Set<string>`)
+  - Skips loading for preset/system fonts (Menlo, Monaco, Courier New, MesloLGS NF)
+  - Calls Tauri IPC `resolve_font_files(familyName)`
+  - For each returned font file:
+    - Creates `new FontFace(familyName, arrayBuffer, { style, weight })` 
+    - Calls `face.load()` then `document.fonts.add(face)`
+  - Returns `true` if at least one font face was loaded, `false` otherwise
+
+### Integration Points
+
+1. **`useTerminalSettingsStore.updateSettings()`** — After normalizing fontFamily, call `loadCustomFont()` before `applyTerminalSettings()`. Font loading is async, so `applyTerminalSettings` should be called after the font is loaded.
+
+2. **`useTerminalSettingsStore.loadSettings()`** — On app startup, after loading persisted settings from Rust, call `loadCustomFont()` for the stored fontFamily. This ensures custom fonts are available before any terminal renders.
+
+3. **`applyTerminalSettings()`** in `terminalTheme.ts` — Keeps the `clearTextureAtlas()` call that was already added. After a custom font is loaded into `document.fonts`, clearing the atlas forces the CanvasAddon to re-render glyphs with the now-available font.
+
+4. **`attachTerminal()`** in `TerminalView.tsx` — Keeps the terminal settings re-application + `clearTextureAtlas()` for terminals that were hidden during font changes.
+
+## Error Handling
+
+- If font family not found on disk: `loadCustomFont` returns `false`, font falls back to monospace (current behavior, no regression)
+- If font file read fails: same graceful fallback, error logged in DEV mode
+- If FontFace constructor throws (corrupt font file): caught, logged, returns `false`
+- No user-facing error notification — the font simply won't render if it can't be loaded
+
+## CSP Impact
+
+None. Font data arrives via Tauri IPC (not a URL fetch), and the `FontFace` constructor with an ArrayBuffer does not trigger CSP `font-src` checks.
+
+## Platform Support
+
+- **macOS**: Full support via CoreText API
+- **Linux/Windows**: `resolve_font_files` returns empty Vec. Custom fonts won't load via this mechanism (same as current behavior). Platform-specific implementations can be added later using fontconfig (Linux) or DirectWrite (Windows).
+
+## Files to Create/Modify
+
+### New files
+- `src-tauri/src/fonts.rs` — Rust font resolution module
+- `src/lib/fontLoader.ts` — TypeScript font loading utility
+
+### Modified files
+- `src-tauri/src/lib.rs` — Register new Tauri command
+- `src-tauri/Cargo.toml` — Add `core-text` and `core-foundation` crate dependencies
+- `src/stores/useTerminalSettingsStore.ts` — Call `loadCustomFont()` in `updateSettings` and `loadSettings`
+- `src/components/terminal/terminalTheme.ts` — Already has `clearTextureAtlas()` (keep as-is)
+- `src/components/terminal/TerminalView.tsx` — Already has settings re-application (keep as-is)
+- `src/lib/tauri.ts` — Add IPC wrapper for `resolve_font_files`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -612,6 +612,19 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
@@ -631,6 +644,18 @@ checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
+dependencies = [
+ "core-foundation",
+ "core-graphics 0.24.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -3948,6 +3973,8 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 name = "shep"
 version = "0.1.4"
 dependencies = [
+ "core-foundation",
+ "core-text",
  "dirs",
  "fix-path-env",
  "libc",
@@ -4204,7 +4231,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,5 +32,7 @@ tauri-plugin-notification = "2"
 libc = "0.2"
 rusqlite = { version = "0.33", features = ["bundled"] }
 notify = { version = "7", features = ["macos_fsevent"] }
+core-text = "21"
+core-foundation = "0.10"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use crate::usage::{LocalUsageDetails, ProviderUsageSnapshot, UsageDb, UsageOverv
 use crate::watcher::GitWatcher;
 use crate::workspace::config::{EditorSettings, KeybindingSettings, RegisteredRepo, RepoInfo, TerminalSettings, UsageSettings, WorkspaceConfig};
 use crate::workspace::manager::WorkspaceManager;
+use crate::fonts;
 
 // ── Workspace commands ──────────────────────────────────────────────
 
@@ -765,4 +766,11 @@ pub async fn kill_port(pid: u32) -> Result<(), String> {
             .map_err(|e| format!("Failed to force-kill process {pid}: {e}"))?;
     }
     Ok(())
+}
+
+// ── Font commands ───────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn resolve_font_files(family_name: &str) -> Vec<fonts::FontFile> {
+    fonts::resolve_font_files_for_family(family_name)
 }

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -1,0 +1,47 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FontFile {
+    /// Raw font file bytes (TTF/OTF)
+    pub data: Vec<u8>,
+    /// Font style, e.g. "Regular", "Bold", "Italic", "Bold Italic"
+    pub style: String,
+}
+
+/// Resolve a font family name to its on-disk font files using the macOS CoreText API.
+/// Returns an empty Vec on non-macOS platforms or if the family is not found.
+#[cfg(target_os = "macos")]
+pub fn resolve_font_files_for_family(family_name: &str) -> Vec<FontFile> {
+    let collection = match core_text::font_collection::create_for_family(family_name) {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+
+    let descriptors = match collection.get_descriptors() {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+
+    let mut result = Vec::new();
+    for desc in descriptors.iter() {
+        let Some(path) = desc.font_path() else {
+            continue;
+        };
+
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+
+        let style = desc.style_name();
+
+        result.push(FontFile { data, style });
+    }
+
+    result
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn resolve_font_files_for_family(_family_name: &str) -> Vec<FontFile> {
+    Vec::new()
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod fonts;
 mod git;
 mod menu;
 mod pty;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ pub fn run() {
             commands::list_listening_ports,
             commands::kill_port,
             commands::open_url,
+            commands::resolve_font_files,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -179,6 +179,26 @@ export default function TerminalView({
       // corrupting xterm's scroll state.
       term.options.theme = createTerminalTheme(useThemeStore.getState().theme);
 
+      // Re-apply terminal settings (font, cursor, scrollback) that may
+      // have changed while this terminal was hidden.  applyTerminalSettings
+      // skips hidden terminals, so we catch up here.
+      const currentSettings = useTerminalSettingsStore.getState().settings;
+      const fontChanged =
+        term.options.fontFamily !== currentSettings.fontFamily ||
+        term.options.fontSize !== currentSettings.fontSize;
+
+      term.options.cursorStyle = currentSettings.cursorStyle;
+      term.options.cursorBlink = currentSettings.cursorBlink;
+      term.options.scrollback = currentSettings.scrollback;
+      term.options.fontFamily = currentSettings.fontFamily;
+      term.options.fontSize = currentSettings.fontSize;
+
+      // If the font changed while hidden, force the renderer to discard
+      // its cached glyph atlas so glyphs are re-drawn with the new font.
+      if (fontChanged) {
+        term.clearTextureAtlas();
+      }
+
       // Refresh the viewport so rendering is restored after visibility
       // changes (e.g. closing settings overlay).
       term.refresh(0, term.rows - 1);

--- a/src/components/terminal/terminalTheme.ts
+++ b/src/components/terminal/terminalTheme.ts
@@ -76,6 +76,11 @@ export function applyTerminalSettings(settings: TerminalSettings): void {
     const el = entry.term.element;
     if (!fontMetricsChanged || !el || el.offsetParent === null) continue;
 
+    // Force the renderer to discard cached glyphs so they are re-drawn
+    // with the new font/size.  Without this the CanvasAddon (or WebGL)
+    // texture atlas keeps stale glyphs rendered in the previous font.
+    entry.term.clearTextureAtlas();
+
     entry.fitAddon.fit();
     entry.term.refresh(0, entry.term.rows - 1);
     resizePty(ptyId, entry.term.cols, entry.term.rows).catch((error) => {

--- a/src/lib/fontLoader.ts
+++ b/src/lib/fontLoader.ts
@@ -1,0 +1,100 @@
+import { resolveFontFiles } from "./tauri";
+import { FONT_OPTIONS } from "./terminalConfig";
+
+/** Font family names that are already loaded or don't need loading. */
+const SKIP_FAMILIES = new Set([
+  ...FONT_OPTIONS.map((f) => f.label),
+  "MesloLGS NF",
+  "Menlo",
+  "Monaco",
+  "Courier New",
+  "monospace",
+  "ui-monospace",
+]);
+
+/** Tracks which font families have already been loaded in this session. */
+const loadedFamilies = new Set<string>();
+
+/**
+ * Extract the primary (first) bare font name from a CSS font-family string.
+ * e.g. "'MonoLisaNikos Nerd Font', monospace" → "MonoLisaNikos Nerd Font"
+ */
+function extractPrimaryFamily(fontFamily: string): string {
+  const first = fontFamily.split(",")[0].trim();
+  // Strip surrounding quotes
+  if (
+    (first.startsWith("'") && first.endsWith("'")) ||
+    (first.startsWith('"') && first.endsWith('"'))
+  ) {
+    return first.slice(1, -1);
+  }
+  return first;
+}
+
+/**
+ * Map a FontFace style string (e.g. "Bold Italic") to CSS font-style
+ * and font-weight descriptor values.
+ */
+function parseFontStyle(style: string): { weight: string; style: string } {
+  const lower = style.toLowerCase();
+  const isBold = lower.includes("bold");
+  const isItalic = lower.includes("italic") || lower.includes("oblique");
+  return {
+    weight: isBold ? "bold" : "normal",
+    style: isItalic ? "italic" : "normal",
+  };
+}
+
+/**
+ * Load a custom font into the browser's font system so it is available
+ * to Canvas 2D (and therefore to xterm.js CanvasAddon).
+ *
+ * Resolves the font family name to on-disk font files via Tauri IPC,
+ * then creates FontFace objects from the binary data and adds them
+ * to document.fonts.
+ *
+ * @returns true if at least one font face was loaded, false otherwise.
+ */
+export async function loadCustomFont(fontFamily: string): Promise<boolean> {
+  const familyName = extractPrimaryFamily(fontFamily);
+
+  // Skip system/preset/bundled fonts — they're already available
+  if (SKIP_FAMILIES.has(familyName)) return false;
+
+  // Skip if already loaded in this session
+  if (loadedFamilies.has(familyName)) return true;
+
+  try {
+    const fontFiles = await resolveFontFiles(familyName);
+    if (fontFiles.length === 0) return false;
+
+    let loaded = false;
+    for (const file of fontFiles) {
+      try {
+        const buffer = new Uint8Array(file.data).buffer;
+        const { weight, style } = parseFontStyle(file.style);
+        const face = new FontFace(familyName, buffer, { weight, style });
+        await face.load();
+        document.fonts.add(face);
+        loaded = true;
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.error(
+            `Failed to load font face "${familyName}" (${file.style}):`,
+            e,
+          );
+        }
+      }
+    }
+
+    if (loaded) {
+      loadedFamilies.add(familyName);
+    }
+    return loaded;
+  } catch (e) {
+    if (import.meta.env.DEV) {
+      console.error(`Failed to resolve font files for "${familyName}":`, e);
+    }
+    return false;
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -18,6 +18,7 @@ import type {
   UsageSettings,
   UsageOverview,
   PortInfo,
+  FontFile,
 } from "./types";
 
 // ── Workspace commands ──────────────────────────────────────────────
@@ -276,4 +277,10 @@ export function listListeningPorts(): Promise<PortInfo[]> {
 
 export function killPort(pid: number): Promise<void> {
   return invoke("kill_port", { pid });
+}
+
+// ── Font commands ───────────────────────────────────────────────────
+
+export function resolveFontFiles(familyName: string): Promise<FontFile[]> {
+  return invoke("resolve_font_files", { familyName });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,11 @@ export interface TerminalSettings {
   fontSize: number;
 }
 
+export interface FontFile {
+  data: number[];
+  style: string;
+}
+
 // ── Runtime state types ─────────────────────────────────────────────
 
 export type CommandStatus = "stopped" | "running" | "crashed";

--- a/src/stores/useTerminalSettingsStore.ts
+++ b/src/stores/useTerminalSettingsStore.ts
@@ -4,6 +4,7 @@ import { getTerminalSettings, saveTerminalSettings } from "../lib/tauri";
 import { applyTerminalSettings } from "../components/terminal/terminalTheme";
 
 import { normalizeTerminalFontFamily, TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE } from "../lib/terminalConfig";
+import { loadCustomFont } from "../lib/fontLoader";
 
 const DEFAULT_SETTINGS: TerminalSettings = {
   cursorStyle: "block",
@@ -35,6 +36,8 @@ export const useTerminalSettingsStore = create<TerminalSettingsStore>((set, get)
         ...settings,
         fontFamily: normalizeTerminalFontFamily(settings.fontFamily),
       };
+      // Load custom font into browser before applying to terminals
+      await loadCustomFont(normalizedSettings.fontFamily);
       set({ settings: normalizedSettings, hasLoaded: true, error: null });
       applyTerminalSettings(normalizedSettings);
       if (normalizedSettings.fontFamily !== settings.fontFamily) {
@@ -56,6 +59,8 @@ export const useTerminalSettingsStore = create<TerminalSettingsStore>((set, get)
         ? { fontFamily: normalizeTerminalFontFamily(partial.fontFamily) }
         : {}),
     };
+    // Load custom font into browser before applying to terminals
+    await loadCustomFont(next.fontFamily);
     // Optimistic update
     set({ settings: next, isSaving: true, error: null });
     applyTerminalSettings(next);


### PR DESCRIPTION
Finally made custom fonts working. This is MacOS-only solution, but so far working correctly