### PR TITLE
Feat: OpenCode token usage

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -371,6 +371,7 @@ fn enabled_providers(workspace: &State<'_, WorkspaceManager>) -> crate::usage::E
     crate::usage::EnabledProviders {
         claude: settings.show_claude,
         codex: settings.show_codex,
+        opencode: settings.show_opencode,
     }
 }
 

--- a/src-tauri/src/usage/db.rs
+++ b/src-tauri/src/usage/db.rs
@@ -43,12 +43,15 @@ fn db_path() -> Result<PathBuf, String> {
 }
 
 fn migrate(conn: &Connection) -> Result<(), String> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);"
-    ).map_err(|e| format!("Failed to create schema_version table: {e}"))?;
+    conn.execute_batch("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);")
+        .map_err(|e| format!("Failed to create schema_version table: {e}"))?;
 
     let version: i64 = conn
-        .query_row("SELECT COALESCE(MAX(version), 0) FROM schema_version", [], |r| r.get(0))
+        .query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+            [],
+            |r| r.get(0),
+        )
         .unwrap_or(0);
 
     if version < 1 {
@@ -121,6 +124,15 @@ fn migrate(conn: &Connection) -> Result<(), String> {
              DELETE FROM ingest_cursors WHERE provider = 'codex';
              INSERT INTO schema_version (version) VALUES (2);"
         ).map_err(|e| format!("Failed to run migration v2: {e}"))?;
+    }
+
+    if version < 3 {
+        // Add cost column - use individual ALTER TABLE statements and ignore errors if columns exist
+        let _ = conn.execute("ALTER TABLE usage_messages ADD COLUMN cost REAL", []);
+        let _ = conn.execute("ALTER TABLE usage_daily ADD COLUMN cost REAL", []);
+
+        conn.execute("INSERT INTO schema_version (version) VALUES (3)", [])
+            .map_err(|e| format!("Failed to run migration v3: {e}"))?;
     }
 
     Ok(())

--- a/src-tauri/src/usage/ingest.rs
+++ b/src-tauri/src/usage/ingest.rs
@@ -28,6 +28,10 @@ pub fn ingest_all(conn: &Connection) -> bool {
         Ok(done) => { if !done { all_done = false; } }
         Err(e) => eprintln!("Codex ingest error: {e}"),
     }
+    match ingest_opencode(conn, MAX_FILES_PER_CYCLE) {
+        Ok(done) => { if !done { all_done = false; } }
+        Err(e) => eprintln!("OpenCode ingest error: {e}"),
+    }
     if let Err(e) = prune_old_messages(conn) {
         eprintln!("Prune error: {e}");
     }
@@ -478,6 +482,122 @@ fn ingest_codex_file(conn: &Connection, path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+// ── OpenCode ───────────────────────────────────────────────
+
+/// Ingests from OpenCode SQLite database. Returns Ok(true) when complete.
+fn ingest_opencode(conn: &Connection, _budget: usize) -> Result<bool, String> {
+    ingest_opencode_db(conn)?;
+    Ok(true)
+}
+
+/// Ingest messages from OpenCode SQLite database (current sessions)
+fn ingest_opencode_db(conn: &Connection) -> Result<(), String> {
+    let db_path = home_join(".local/share/opencode/opencode.db")?;
+    if !db_path.exists() {
+        return Ok(());
+    }
+
+    // Open OpenCode database in read-only mode
+    let opencode_conn =
+        Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| format!("Failed to open OpenCode database: {e}"))?;
+
+    // Get the max message ID we've already ingested
+    let last_id: String = conn
+        .query_row(
+            "SELECT COALESCE(MAX(session_id), '') FROM usage_messages WHERE provider = 'opencode' AND session_id LIKE 'msg_%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or_default();
+
+    // Query messages with tokens from OpenCode database
+    let mut query = opencode_conn
+        .prepare(
+            "SELECT id, json_extract(data, '$.modelID'),
+                    json_extract(data, '$.tokens.input'),
+                    json_extract(data, '$.tokens.output'),
+                    json_extract(data, '$.tokens.reasoning'),
+                    json_extract(data, '$.tokens.cache.read'),
+                    json_extract(data, '$.tokens.cache.write'),
+                    json_extract(data, '$.time.created'),
+                    json_extract(data, '$.path.cwd'),
+                    json_extract(data, '$.path.root'),
+                    json_extract(data, '$.cost')
+             FROM message
+             WHERE data LIKE '%\"tokens\":{%'
+               AND (? = '' OR id > ?)
+              ORDER BY id ASC",
+        )
+        .map_err(|e| format!("Failed to prepare query: {e}"))?;
+
+    let rows = query
+        .query_map(params![last_id, last_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,         // id
+                row.get::<_, Option<String>>(1)?, // modelID
+                row.get::<_, Option<i64>>(2)?,    // input
+                row.get::<_, Option<i64>>(3)?,    // output
+                row.get::<_, Option<i64>>(4)?,    // reasoning
+                row.get::<_, Option<i64>>(5)?,    // cache_read
+                row.get::<_, Option<i64>>(6)?,    // cache_write
+                row.get::<_, Option<i64>>(7)?,    // time_created
+                row.get::<_, Option<String>>(8)?, // cwd
+                row.get::<_, Option<String>>(9)?, // root
+                row.get::<_, Option<f64>>(10)?,   // cost
+            ))
+        })
+        .map_err(|e| format!("Failed to query messages: {e}"))?;
+
+    conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
+
+    for row in rows {
+        let row = row.map_err(|e| format!("Row error: {e}"))?;
+        let (id, model, input, output, reasoning, cache_read, cache_write, time_created, cwd, root, cost) =
+            row;
+
+        // Skip if no tokens
+        let input = input.unwrap_or(0);
+        let output = output.unwrap_or(0);
+        let reasoning = reasoning.unwrap_or(0);
+        let cache_read = cache_read.unwrap_or(0);
+        let cache_write = cache_write.unwrap_or(0);
+        let total = input + output + reasoning + cache_read + cache_write;
+
+        if total == 0 {
+            continue;
+        }
+
+        // Extract project name from path
+        let project = cwd
+            .or(root)
+            .and_then(|p| p.split('/').rfind(|s| !s.is_empty()).map(|s| s.to_string()))
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let model = model.unwrap_or_else(|| "unknown".to_string());
+        let timestamp = time_created.map(|ms| ms / 1000).unwrap_or(0);
+
+        // Delete old rows for this message and re-insert
+        conn.execute(
+            "DELETE FROM usage_messages WHERE provider = 'opencode' AND session_id = ?1",
+            params![id],
+        )
+        .map_err(|e| e.to_string())?;
+
+        conn.execute(
+            "INSERT INTO usage_messages (provider, session_id, project, model, timestamp, tokens_input, tokens_output, tokens_cache_write, tokens_cache_read, tokens_thoughts, tokens_total, cost)
+             VALUES ('opencode', ?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8, ?9, ?10)",
+            params![
+                id, project, model, timestamp as i64,
+                input as i64, output as i64, cache_read as i64, reasoning as i64, total as i64, cost
+            ],
+        ).map_err(|e| e.to_string())?;
+    }
+
+    conn.execute_batch("COMMIT").map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 // ── Maintenance ───────────────────────────────────────────
 
 fn prune_old_messages(conn: &Connection) -> Result<(), String> {
@@ -524,9 +644,7 @@ fn upsert_cursor(conn: &Connection, file_path: &str, provider: &str, file_size: 
 }
 
 fn clean_cursors(conn: &Connection, provider: &str, valid_files: &[PathBuf]) {
-    let mut stmt = match conn
-        .prepare("SELECT file_path FROM ingest_cursors WHERE provider = ?1")
-    {
+    let mut stmt = match conn.prepare("SELECT file_path FROM ingest_cursors WHERE provider = ?1") {
         Ok(s) => s,
         Err(_) => return,
     };

--- a/src-tauri/src/usage/mod.rs
+++ b/src-tauri/src/usage/mod.rs
@@ -101,6 +101,8 @@ static PROVIDER_CACHE: Mutex<ProviderCache> = Mutex::new(ProviderCache {
 pub struct EnabledProviders {
     pub claude: bool,
     pub codex: bool,
+    #[allow(dead_code)]
+    pub opencode: bool,
 }
 
 /// Fetch snapshots for all providers from whatever is currently in the DB.
@@ -115,6 +117,7 @@ pub fn get_all_usage_snapshots(db: &UsageDb, enabled: &EnabledProviders) -> Vec<
         claude_snapshot(&conn),
         codex_snapshot(&conn),
         gemini_snapshot(&conn),
+        opencode_snapshot(&conn),
     ]
 }
 
@@ -127,6 +130,7 @@ pub fn get_usage_snapshot(db: &UsageDb, provider: &str, enabled: &EnabledProvide
         "codex" => Ok(codex_snapshot(&conn)),
         "claude" => Ok(claude_snapshot(&conn)),
         "gemini" => Ok(gemini_snapshot(&conn)),
+        "opencode" => Ok(opencode_snapshot(&conn)),
         other => Err(format!("Unsupported usage provider: {other}")),
     }
 }
@@ -347,6 +351,47 @@ fn gemini_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
     ProviderUsageSnapshot {
         provider: "gemini".to_string(),
         status: if local.is_some() { "ready".to_string() } else { "unavailable".to_string() },
+        fetched_at,
+        summary_windows,
+        extra_windows: Vec::new(),
+        local_details: local,
+        error: None,
+    }
+}
+
+fn opencode_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
+    let fetched_at = helpers::now_iso_string();
+    let local = queries::local_details(conn, "opencode");
+    let mut summary_windows = Vec::new();
+
+    if let Some(ref details) = local {
+        for (window, tokens) in [
+            ("5h", details.tokens_5h),
+            ("7d", details.tokens_7d),
+            ("30d", details.tokens_30d),
+        ] {
+            summary_windows.push(UsageWindowSnapshot {
+                provider: "opencode".to_string(),
+                window: window.to_string(),
+                label: window.to_string(),
+                source_type: "local".to_string(),
+                confidence: "observed".to_string(),
+                used_percent: None,
+                remaining_percent: None,
+                reset_at: None,
+                token_total: Some(tokens),
+                pace_status: None,
+            });
+        }
+    }
+
+    ProviderUsageSnapshot {
+        provider: "opencode".to_string(),
+        status: if local.is_some() {
+            "ready".to_string()
+        } else {
+            "unavailable".to_string()
+        },
         fetched_at,
         summary_windows,
         extra_windows: Vec::new(),

--- a/src-tauri/src/usage/queries.rs
+++ b/src-tauri/src/usage/queries.rs
@@ -80,6 +80,13 @@ fn calculate_cost(pricing: &ModelPricing, input: i64, output: i64, cache_read: i
 
 /// Calculate cost for a windowed query (total tokens by type for a given provider/cutoff).
 fn windowed_cost(conn: &Connection, provider: &str, cutoff: i64, pricing: &HashMap<String, ModelPricing>) -> Option<f64> {
+    if let Some(cost) = conn.query_row(
+        "SELECT SUM(cost) FROM usage_messages WHERE provider = ?1 AND timestamp >= ?2 AND cost IS NOT NULL AND cost > 0",
+        params![provider, cutoff],
+        |row| row.get::<_, f64>(0)
+    ).ok() {
+        return Some(cost);
+    }
     let mut stmt = conn.prepare(
         "SELECT COALESCE(model, 'unknown'), SUM(tokens_input), SUM(tokens_output), SUM(tokens_cache_read), SUM(tokens_cache_write), SUM(tokens_thoughts)
          FROM usage_messages WHERE provider = ?1 AND timestamp >= ?2
@@ -409,6 +416,13 @@ fn query_top_projects_since(conn: &Connection, provider: &str, since: i64, prici
 
 /// Calculate cost for a specific project by summing per-model costs.
 fn windowed_cost_for_project(conn: &Connection, provider: &str, since: i64, project: &str, pricing: &HashMap<String, ModelPricing>) -> Option<f64> {
+    if let Some(cost) = conn.query_row(
+        "SELECT SUM(cost) FROM usage_messages WHERE provider = ?1 AND timestamp >= ?2 AND COALESCE(project, 'unknown') = ?3 AND cost IS NOT NULL AND cost > 0",
+        params![provider, since, project],
+        |row| row.get::<_, f64>(0)
+    ).ok() {
+        return Some(cost);
+    }
     let mut stmt = conn.prepare(
         "SELECT COALESCE(model, 'unknown'), SUM(tokens_input), SUM(tokens_output), SUM(tokens_cache_read), SUM(tokens_cache_write), SUM(tokens_thoughts)
          FROM usage_messages WHERE provider = ?1 AND timestamp >= ?2 AND COALESCE(project, 'unknown') = ?3
@@ -658,6 +672,13 @@ fn query_named_trend(
 }
 
 fn windowed_cost_for_provider(conn: &Connection, provider: &str, since: i64, pricing: &HashMap<String, ModelPricing>) -> Option<f64> {
+    if let Some(cost) = conn.query_row(
+        "SELECT SUM(cost) FROM usage_messages WHERE provider = ?1 AND timestamp >= ?2 AND cost IS NOT NULL AND cost > 0",
+        params![provider, since],
+        |row| row.get::<_, f64>(0)
+    ).ok() {
+        return Some(cost);
+    }
     let mut stmt = conn.prepare(
         "SELECT COALESCE(model, 'unknown'), SUM(tokens_input), SUM(tokens_output), SUM(tokens_cache_read), SUM(tokens_cache_write), SUM(tokens_thoughts)
          FROM usage_messages

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -116,6 +116,8 @@ pub struct UsageSettings {
     pub show_codex: bool,
     #[serde(default = "default_true", rename = "showGemini")]
     pub show_gemini: bool,
+    #[serde(default = "default_true", rename = "showOpencode")]
+    pub show_opencode: bool,
 }
 
 impl Default for UsageSettings {
@@ -124,6 +126,7 @@ impl Default for UsageSettings {
             show_claude: true,
             show_codex: true,
             show_gemini: true,
+            show_opencode: true,
         }
     }
 }

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -326,11 +326,11 @@ export default function SettingsPanel() {
       <h2 className="section-label !p-0 mb-4">Usage Providers</h2>
 
       <div className="flex flex-wrap gap-3">
-        {(["claude", "codex", "gemini"] as UsageProvider[]).map((provider) => {
-          const key = provider === "claude" ? "showClaude" : provider === "codex" ? "showCodex" : "showGemini";
+        {(["claude", "codex", "gemini", "opencode"] as UsageProvider[]).map((provider) => {
+          const key = provider === "claude" ? "showClaude" : provider === "codex" ? "showCodex" : provider === "gemini" ? "showGemini" : "showOpencode";
           const active = usageSettings[key];
           const logo = assistantLogoSrc[provider];
-          const label = provider === "claude" ? "Claude" : provider === "codex" ? "Codex" : "Gemini";
+          const label = provider === "claude" ? "Claude" : provider === "codex" ? "Codex" : provider === "gemini" ? "Gemini" : "OpenCode";
           return (
             <button
               key={provider}

--- a/src/components/sidebar/SidebarUsage.tsx
+++ b/src/components/sidebar/SidebarUsage.tsx
@@ -6,7 +6,7 @@ import type { UsageProvider } from "../../lib/types";
 import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogos";
 import { formatPercent, formatTokenCount, formatCost, computePace } from "../usage/usageHelpers";
 
-const ALL_PROVIDERS: UsageProvider[] = ["claude", "codex", "gemini"];
+const ALL_PROVIDERS: UsageProvider[] = ["claude", "codex", "gemini", "opencode"];
 const WINDOWS: { key: TimeWindow; label: string }[] = [
   { key: "5h", label: "5h" },
   { key: "7d", label: "7d" },
@@ -48,6 +48,7 @@ export default function SidebarUsage() {
     if (p === "claude") return usageSettings.showClaude;
     if (p === "codex") return usageSettings.showCodex;
     if (p === "gemini") return usageSettings.showGemini;
+    if (p === "opencode") return usageSettings.showOpencode;
     return true;
   }), [usageSettings]);
 

--- a/src/components/usage/UsagePanel.tsx
+++ b/src/components/usage/UsagePanel.tsx
@@ -414,7 +414,7 @@ function ProviderLimits({
 }) {
   if (window !== "5h" && window !== "7d") return null;
 
-  const providers = (["claude", "codex", "gemini"] as UsageProvider[]).filter((p) => {
+  const providers = (["claude", "codex", "gemini", "opencode"] as UsageProvider[]).filter((p) => {
     const snap = snapshots[p];
     if (!snap) return false;
     const w = snap.summaryWindows.find((sw) => sw.window === window);

--- a/src/components/usage/usageHelpers.ts
+++ b/src/components/usage/usageHelpers.ts
@@ -19,6 +19,8 @@ export function getProviderLabel(provider: UsageProvider): string {
       return "Claude";
     case "gemini":
       return "Gemini";
+    case "opencode":
+      return "OpenCode";
   }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -160,12 +160,13 @@ export interface PtyColorTheme {
 
 // ── Usage ──────────────────────────────────────────────────────────
 
-export type UsageProvider = "codex" | "claude" | "gemini";
+export type UsageProvider = "codex" | "claude" | "gemini" | "opencode";
 
 export interface UsageSettings {
   showClaude: boolean;
   showCodex: boolean;
   showGemini: boolean;
+  showOpencode: boolean;
 }
 export type UsageSourceType = "provider" | "local";
 export type UsageConfidence = "official" | "observed" | "estimated";

--- a/src/stores/useUsageSettingsStore.ts
+++ b/src/stores/useUsageSettingsStore.ts
@@ -16,10 +16,11 @@ const KEY_MAP: Record<UsageProvider, keyof UsageSettings> = {
   claude: "showClaude",
   codex: "showCodex",
   gemini: "showGemini",
+  opencode: "showOpencode",
 };
 
 export const useUsageSettingsStore = create<UsageSettingsStore>((set, get) => ({
-  settings: { showClaude: true, showCodex: true, showGemini: true },
+  settings: { showClaude: true, showCodex: true, showGemini: true, showOpencode: true },
   hasLoaded: false,
   isSaving: false,
   error: null,


### PR DESCRIPTION
## Feature: OpenCode Usage Tracking Integration

Adds OpenCode as a new usage provider, allowing Shep to track OpenCode AI assistant usage alongside existing providers.

I tried to use opencode files at first like Codex provider but I noticed OpenCode migrated to SQLite a few months ago, and the local DB (`~/.local/share/opencode/opencode.db`) contains all token usage data needed. 

Reads OpenCode's DB in read-only mode and uses it as the source of truth for accurate cost stats.

---

### Changes

**Backend (Rust/Tauri)**

- `ingest.rs`: Reads OpenCode's SQLite DB directly. Extracts tokens (input, output, reasoning, cache), cost, model, timestamps, and project from JSON data
- `mod.rs`: Added `opencode_snapshot()` and `opencode` to `EnabledProviders`
- `config.rs`: Added `show_opencode` toggle (default: true)
- `db.rs`: Migration v3 adds `cost REAL` column to `usage_messages` and `usage_daily`
- `queries.rs`: Cost functions now use stored `cost` value when available

**Frontend (React/TypeScript)**

- Added `opencode` to `UsageProvider` type union
- Settings, sidebar, and usage panels include OpenCode toggle/display

---

### Design Choices

| Choice | Rationale |
|--------|-----------|
| Read-only SQLite | Safely access OpenCode's DB without modification risk |
| Incremental via `session_id` | Skips already-processed messages |
| Store cost directly | OpenCode provides cost — use it instead of recalculating |
