### PR TITLE
Agent sessions sidebar, TODO.md to-dos, sidebar polish, terminal scroll fixes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,6 +13,7 @@ use crate::git;
 use crate::git::{ChangedFile, CreatedWorktree, DiffFileStat, GitStatus, WorktreeEntry};
 use crate::pty::manager::PtyManager;
 use crate::pty::session::{PtyColorTheme, PtyOutput};
+use crate::todos::{self, TodoFile};
 use crate::usage::{
     LocalUsageDetails, ProviderUsageSnapshot, UsageDb, UsageOverview, UsageProjectAliasReviewItem,
 };
@@ -453,6 +454,28 @@ pub fn get_computer_name() -> String {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .unwrap_or_default()
+}
+
+// ── Todo commands ───────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn read_todos(repo_path: &str) -> Result<Vec<TodoFile>, String> {
+    todos::read_todos(repo_path)
+}
+
+#[tauri::command]
+pub fn toggle_todo(
+    file_path: &str,
+    line: usize,
+    expected_text: &str,
+    checked: bool,
+) -> Result<(), String> {
+    todos::toggle_todo(file_path, line, expected_text, checked)
+}
+
+#[tauri::command]
+pub fn add_todo(repo_path: &str, file_path: Option<&str>, text: &str) -> Result<(), String> {
+    todos::add_todo(repo_path, file_path, text)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -489,6 +489,7 @@ fn enabled_providers(workspace: &State<'_, WorkspaceManager>) -> crate::usage::E
         claude: settings.claude.show,
         codex: settings.codex.show,
         gemini: settings.gemini.show,
+        antigravity: settings.antigravity.show,
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod git;
 mod menu;
 mod pi_config;
 mod pty;
+mod todos;
 mod usage;
 mod watcher;
 mod workspace;
@@ -130,6 +131,9 @@ pub fn run() {
             commands::git_switch_branch,
             commands::git_create_branch,
             commands::git_diff_stats,
+            commands::read_todos,
+            commands::toggle_todo,
+            commands::add_todo,
             commands::check_command_exists,
             commands::get_usage_settings,
             commands::save_usage_settings,

--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -1,0 +1,330 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Directories never scanned for todo files — build artifacts, deps, VCS internals.
+const IGNORED_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    ".next",
+    "dist",
+    "build",
+    "__pycache__",
+    "vendor",
+    ".shep-worktrees",
+];
+
+/// Filenames (lowercased) recognized as todo files.
+const TODO_FILENAMES: &[&str] = &["todo.md", "todos.md"];
+
+/// How deep below the repo root to look for todo files.
+const MAX_SCAN_DEPTH: usize = 3;
+
+/// Hard cap on discovered files so a pathological repo can't flood the UI.
+const MAX_TODO_FILES: usize = 20;
+
+/// Skip parsing files larger than this — a real todo list is never 1 MB.
+const MAX_FILE_BYTES: u64 = 1024 * 1024;
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TodoItem {
+    /// 0-based line index in the file; used for surgical edits.
+    pub line: usize,
+    pub text: String,
+    pub checked: bool,
+    /// Leading whitespace width, for rendering nested items.
+    pub indent: usize,
+    /// Nearest preceding markdown heading, if any.
+    pub section: Option<String>,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TodoFile {
+    pub path: String,
+    pub relative_path: String,
+    pub items: Vec<TodoItem>,
+}
+
+pub fn read_todos(repo_path: &str) -> Result<Vec<TodoFile>, String> {
+    let root = PathBuf::from(repo_path);
+    if !root.is_dir() {
+        return Err(format!("Not a directory: {repo_path}"));
+    }
+
+    let mut found: Vec<PathBuf> = Vec::new();
+    scan_dir(&root, 0, &mut found);
+
+    // Root-level file first, then shallower paths, then alphabetical.
+    found.sort_by_key(|p| (p.components().count(), p.clone()));
+    found.truncate(MAX_TODO_FILES);
+
+    let mut files = Vec::new();
+    for path in found {
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let relative_path = path
+            .strip_prefix(&root)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| path.to_string_lossy().to_string());
+        files.push(TodoFile {
+            path: path.to_string_lossy().to_string(),
+            relative_path,
+            items: parse_items(&content),
+        });
+    }
+    Ok(files)
+}
+
+pub fn toggle_todo(
+    file_path: &str,
+    line: usize,
+    expected_text: &str,
+    checked: bool,
+) -> Result<(), String> {
+    let content =
+        fs::read_to_string(file_path).map_err(|e| format!("Failed to read {file_path}: {e}"))?;
+    let mut lines: Vec<String> = content.split('\n').map(String::from).collect();
+
+    let target = lines
+        .get(line)
+        .ok_or_else(|| "To-do list changed on disk — try again".to_string())?;
+    let parsed = parse_checkbox_line(target)
+        .ok_or_else(|| "To-do list changed on disk — try again".to_string())?;
+    if parsed.text != expected_text {
+        return Err("To-do list changed on disk — try again".to_string());
+    }
+
+    // The first '[' on a checkbox line is the marker; flip only that byte.
+    let bracket = target.find('[').ok_or("Malformed to-do line")?;
+    let mut updated = target.clone();
+    updated.replace_range(bracket + 1..bracket + 2, if checked { "x" } else { " " });
+    lines[line] = updated;
+
+    fs::write(file_path, lines.join("\n"))
+        .map_err(|e| format!("Failed to write {file_path}: {e}"))
+}
+
+pub fn add_todo(repo_path: &str, file_path: Option<&str>, text: &str) -> Result<(), String> {
+    let text = text.trim();
+    if text.is_empty() {
+        return Err("To-do text is empty".to_string());
+    }
+
+    let path = match file_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            // Lazy creation: the file materializes with the first to-do.
+            let path = Path::new(repo_path).join("TODO.md");
+            if !path.exists() {
+                return fs::write(&path, format!("# TODO\n\n- [ ] {text}\n"))
+                    .map_err(|e| format!("Failed to create TODO.md: {e}"));
+            }
+            path
+        }
+    };
+
+    let content = fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    let mut lines: Vec<String> = content.split('\n').map(String::from).collect();
+
+    // Insert after the last existing checkbox so the new item joins the list
+    // block instead of landing below trailing notes; fall back to EOF.
+    let insert_at = lines
+        .iter()
+        .rposition(|l| parse_checkbox_line(l).is_some())
+        .map(|i| i + 1)
+        .unwrap_or(lines.len());
+    lines.insert(insert_at, format!("- [ ] {text}"));
+
+    let mut joined = lines.join("\n");
+    if !joined.ends_with('\n') {
+        joined.push('\n');
+    }
+    fs::write(&path, joined).map_err(|e| format!("Failed to write {}: {e}", path.display()))
+}
+
+fn scan_dir(dir: &Path, depth: usize, found: &mut Vec<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+
+        if path.is_dir() {
+            if depth + 1 > MAX_SCAN_DEPTH || name.starts_with('.') || IGNORED_DIRS.contains(&name)
+            {
+                continue;
+            }
+            scan_dir(&path, depth + 1, found);
+        } else if TODO_FILENAMES.contains(&name.to_lowercase().as_str()) {
+            let small = entry.metadata().map(|m| m.len() <= MAX_FILE_BYTES).unwrap_or(false);
+            if small {
+                found.push(path);
+            }
+        }
+    }
+}
+
+struct ParsedCheckbox<'a> {
+    text: &'a str,
+    checked: bool,
+    indent: usize,
+}
+
+/// Parse a GFM task-list line: `- [ ] text`, `- [x] text` (also `*`/`+` bullets).
+fn parse_checkbox_line(line: &str) -> Option<ParsedCheckbox<'_>> {
+    let trimmed = line.trim_start();
+    let indent = line.len() - trimmed.len();
+
+    let rest = trimmed
+        .strip_prefix("- ")
+        .or_else(|| trimmed.strip_prefix("* "))
+        .or_else(|| trimmed.strip_prefix("+ "))?;
+    let rest = rest.trim_start();
+
+    let mut chars = rest.chars();
+    if chars.next() != Some('[') {
+        return None;
+    }
+    let mark = chars.next()?;
+    if chars.next() != Some(']') {
+        return None;
+    }
+    let checked = match mark {
+        ' ' => false,
+        'x' | 'X' => true,
+        _ => return None,
+    };
+
+    let after = chars.as_str();
+    if !after.is_empty() && !after.starts_with(' ') {
+        return None;
+    }
+    Some(ParsedCheckbox {
+        text: after.trim(),
+        checked,
+        indent,
+    })
+}
+
+fn parse_items(content: &str) -> Vec<TodoItem> {
+    let mut items = Vec::new();
+    let mut section: Option<String> = None;
+
+    for (line_idx, line) in content.split('\n').enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            let title = trimmed.trim_start_matches('#');
+            if title.starts_with(' ') || title.is_empty() {
+                let title = title.trim();
+                section = (!title.is_empty()).then(|| title.to_string());
+            }
+            continue;
+        }
+        if let Some(parsed) = parse_checkbox_line(line) {
+            if parsed.text.is_empty() {
+                continue;
+            }
+            items.push(TodoItem {
+                line: line_idx,
+                text: parsed.text.to_string(),
+                checked: parsed.checked,
+                indent: parsed.indent,
+                section: section.clone(),
+            });
+        }
+    }
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_checkboxes_with_sections() {
+        let content = "# TODO\n\n## Now\n- [ ] first\n  - [x] nested done\n* [ ] star bullet\n\n## Later\n- [-] declined ignored\n- [ ]\n- [ ] last\n";
+        let items = parse_items(content);
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0].text, "first");
+        assert_eq!(items[0].section.as_deref(), Some("Now"));
+        assert!(!items[0].checked);
+        assert!(items[1].checked);
+        assert_eq!(items[1].indent, 2);
+        assert_eq!(items[3].text, "last");
+        assert_eq!(items[3].section.as_deref(), Some("Later"));
+    }
+
+    #[test]
+    fn ignores_non_checkbox_lines() {
+        let items = parse_items("plain text\n- regular bullet\n-[ ] no space\n[ ] no bullet\n");
+        assert!(items.is_empty());
+    }
+
+    fn temp_repo(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("shep-todos-test-{name}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn toggle_flips_only_the_marker() {
+        let dir = temp_repo("toggle");
+        let path = dir.join("TODO.md");
+        fs::write(&path, "# TODO\n\n- [ ] keep [brackets] intact\n- [x] other\n").unwrap();
+        let p = path.to_string_lossy().to_string();
+
+        toggle_todo(&p, 2, "keep [brackets] intact", true).unwrap();
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "# TODO\n\n- [x] keep [brackets] intact\n- [x] other\n"
+        );
+
+        // Stale expected text → error, file untouched
+        assert!(toggle_todo(&p, 3, "something else", false).is_err());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_creates_file_lazily_and_inserts_after_last_item() {
+        let dir = temp_repo("add");
+        let repo = dir.to_string_lossy().to_string();
+
+        add_todo(&repo, None, "first task").unwrap();
+        let path = dir.join("TODO.md");
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "# TODO\n\n- [ ] first task\n"
+        );
+
+        fs::write(&path, "# TODO\n\n- [ ] a\n\ntrailing notes\n").unwrap();
+        add_todo(&repo, Some(&path.to_string_lossy()), "b").unwrap();
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "# TODO\n\n- [ ] a\n- [ ] b\n\ntrailing notes\n"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discovers_files_case_insensitively_and_skips_ignored_dirs() {
+        let dir = temp_repo("scan");
+        fs::write(dir.join("todo.md"), "- [ ] root\n").unwrap();
+        fs::create_dir_all(dir.join("docs")).unwrap();
+        fs::write(dir.join("docs/TODOS.md"), "- [ ] nested\n").unwrap();
+        fs::create_dir_all(dir.join("node_modules/pkg")).unwrap();
+        fs::write(dir.join("node_modules/pkg/TODO.md"), "- [ ] ignored\n").unwrap();
+
+        let files = read_todos(&dir.to_string_lossy()).unwrap();
+        let rels: Vec<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
+        assert_eq!(rels, vec!["todo.md", "docs/TODOS.md"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/usage/db.rs
+++ b/src-tauri/src/usage/db.rs
@@ -256,6 +256,47 @@ fn migrate(conn: &Connection) -> Result<(), String> {
         .map_err(|e| format!("Failed to run migration v9: {e}"))?;
     }
 
+    if version < 10 {
+        conn.execute_batch(
+            "DELETE FROM usage_messages WHERE provider = 'antigravity';
+             DELETE FROM usage_daily WHERE provider = 'antigravity';
+             DELETE FROM ingest_cursors WHERE provider = 'antigravity';
+             INSERT INTO schema_version (version) VALUES (10);",
+        )
+        .map_err(|e| format!("Failed to run migration v10: {e}"))?;
+    }
+
+    if version < 11 {
+        if column_exists(conn, "usage_messages", "pricing_provider")
+            && column_exists(conn, "usage_messages", "model")
+        {
+            conn.execute_batch(
+                "UPDATE usage_messages
+                 SET pricing_provider = 'google'
+                 WHERE provider = 'antigravity' AND lower(COALESCE(model, '')) LIKE '%gemini%';
+                 UPDATE usage_messages
+                 SET pricing_provider = 'anthropic'
+                 WHERE provider = 'antigravity' AND lower(COALESCE(model, '')) LIKE '%claude%';",
+            )
+            .map_err(|e| format!("Failed to run migration v11 usage_messages update: {e}"))?;
+        }
+        if column_exists(conn, "usage_daily", "pricing_provider")
+            && column_exists(conn, "usage_daily", "model")
+        {
+            conn.execute_batch(
+                "UPDATE usage_daily
+                 SET pricing_provider = 'google'
+                 WHERE provider = 'antigravity' AND lower(COALESCE(model, '')) LIKE '%gemini%';
+                 UPDATE usage_daily
+                 SET pricing_provider = 'anthropic'
+                 WHERE provider = 'antigravity' AND lower(COALESCE(model, '')) LIKE '%claude%';",
+            )
+            .map_err(|e| format!("Failed to run migration v11 usage_daily update: {e}"))?;
+        }
+        conn.execute("INSERT INTO schema_version (version) VALUES (11)", [])
+            .map_err(|e| format!("Failed to run migration v11: {e}"))?;
+    }
+
     Ok(())
 }
 
@@ -361,7 +402,7 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM model_pricing", [], |row| row.get(0))
             .unwrap();
 
-        assert_eq!(version, 9);
+        assert_eq!(version, 11);
         assert!(pricing_rows > 0);
     }
 
@@ -400,7 +441,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(stale_count, 0);
-        assert_eq!(version, 9);
+        assert_eq!(version, 11);
     }
 
     #[test]
@@ -456,6 +497,126 @@ mod tests {
 
         assert_eq!(codex_rows, 0);
         assert_eq!(claude_rows, 3);
-        assert_eq!(version, 9);
+        assert_eq!(version, 11);
+    }
+
+    #[test]
+    fn v10_clears_antigravity_usage_for_model_reingest() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL);
+             INSERT INTO schema_version (version) VALUES (9);
+             CREATE TABLE usage_messages (provider TEXT);
+             CREATE TABLE usage_daily (provider TEXT);
+             CREATE TABLE ingest_cursors (provider TEXT);
+             INSERT INTO usage_messages (provider) VALUES ('antigravity'), ('claude');
+             INSERT INTO usage_daily (provider) VALUES ('antigravity'), ('claude');
+             INSERT INTO ingest_cursors (provider) VALUES ('antigravity'), ('claude');",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let antigravity_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                    SELECT provider FROM usage_messages
+                    UNION ALL
+                    SELECT provider FROM usage_daily
+                    UNION ALL
+                    SELECT provider FROM ingest_cursors
+                 ) WHERE provider = 'antigravity'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let claude_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                    SELECT provider FROM usage_messages
+                    UNION ALL
+                    SELECT provider FROM usage_daily
+                    UNION ALL
+                    SELECT provider FROM ingest_cursors
+                 ) WHERE provider = 'claude'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let version: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(antigravity_rows, 0);
+        assert_eq!(claude_rows, 3);
+        assert_eq!(version, 11);
+    }
+
+    #[test]
+    fn v11_maps_antigravity_pricing_to_underlying_provider() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL);
+             INSERT INTO schema_version (version) VALUES (10);
+             CREATE TABLE usage_messages (provider TEXT, model TEXT, pricing_provider TEXT);
+             CREATE TABLE usage_daily (provider TEXT, model TEXT, pricing_provider TEXT);
+             INSERT INTO usage_messages (provider, model, pricing_provider) VALUES
+                ('antigravity', 'Gemini 3.5 Flash (Medium)', 'antigravity'),
+                ('antigravity', 'Claude Sonnet 4.6 (Thinking)', 'antigravity'),
+                ('antigravity', 'GPT-OSS 120B', 'antigravity');
+             INSERT INTO usage_daily (provider, model, pricing_provider) VALUES
+                ('antigravity', 'Gemini 3.5 Flash (Medium)', 'antigravity'),
+                ('antigravity', 'Claude Sonnet 4.6 (Thinking)', 'antigravity');",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let google_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                    SELECT pricing_provider FROM usage_messages
+                    UNION ALL
+                    SELECT pricing_provider FROM usage_daily
+                 ) WHERE pricing_provider = 'google'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let anthropic_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                    SELECT pricing_provider FROM usage_messages
+                    UNION ALL
+                    SELECT pricing_provider FROM usage_daily
+                 ) WHERE pricing_provider = 'anthropic'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let unknown_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_messages
+                 WHERE model = 'GPT-OSS 120B' AND pricing_provider = 'antigravity'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let version: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(google_rows, 2);
+        assert_eq!(anthropic_rows, 2);
+        assert_eq!(unknown_rows, 1);
+        assert_eq!(version, 11);
     }
 }

--- a/src-tauri/src/usage/ingest.rs
+++ b/src-tauri/src/usage/ingest.rs
@@ -32,6 +32,14 @@ pub fn ingest_all(conn: &Connection) -> bool {
         }
         Err(e) => eprintln!("Gemini ingest error: {e}"),
     }
+    match ingest_antigravity(conn, MAX_FILES_PER_CYCLE) {
+        Ok(done) => {
+            if !done {
+                all_done = false;
+            }
+        }
+        Err(e) => eprintln!("Antigravity ingest error: {e}"),
+    }
     match ingest_codex(conn, MAX_FILES_PER_CYCLE) {
         Ok(done) => {
             if !done {
@@ -345,6 +353,274 @@ fn ingest_gemini_file(conn: &Connection, path: &Path) -> Result<(), String> {
 
     upsert_cursor(conn, &path_str, "gemini", file_size, file_size, mtime)?;
     Ok(())
+}
+
+// ── Antigravity ───────────────────────────────────────────
+
+/// Returns Ok(true) if fully caught up, Ok(false) if more files remain.
+fn ingest_antigravity(conn: &Connection, budget: usize) -> Result<bool, String> {
+    let brain_dir = home_join(".gemini/antigravity-cli/brain")?;
+    if !brain_dir.exists() {
+        return Ok(true);
+    }
+
+    let mut by_session: std::collections::BTreeMap<String, PathBuf> = std::collections::BTreeMap::new();
+    for path in walk_files(&brain_dir) {
+        let file_name = path.file_name().and_then(|n| n.to_str());
+        if file_name != Some("transcript_full.jsonl") && file_name != Some("transcript.jsonl") {
+            continue;
+        }
+        let Some(session_id) = antigravity_session_id(&path) else {
+            continue;
+        };
+        let is_full = file_name == Some("transcript_full.jsonl");
+        let replace = by_session
+            .get(&session_id)
+            .map(|existing| {
+                existing.file_name().and_then(|n| n.to_str()) != Some("transcript_full.jsonl") && is_full
+            })
+            .unwrap_or(true);
+        if replace {
+            by_session.insert(session_id, path);
+        }
+    }
+    let transcript_files: Vec<_> = by_session.into_values().collect();
+
+    conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
+
+    let mut processed = 0;
+    let mut skipped_remaining = false;
+    let history = read_antigravity_history();
+
+    for path in &transcript_files {
+        if processed >= budget {
+            skipped_remaining = true;
+            break;
+        }
+        let path_str = path.to_string_lossy().to_string();
+        let meta = match fs::metadata(path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let file_size = meta.len() as i64;
+        let mtime = file_mtime(&meta);
+        let cursor = get_cursor(conn, &path_str);
+        let needs_work = match &cursor {
+            Some((size, _, mt)) => *size != file_size || *mt != mtime,
+            None => true,
+        };
+        if !needs_work {
+            continue;
+        }
+
+        processed += 1;
+        if let Err(e) = ingest_antigravity_file(conn, path, &history) {
+            eprintln!("Antigravity ingest error for {}: {e}", path.display());
+        }
+    }
+
+    if !skipped_remaining {
+        clean_cursors(conn, "antigravity", &transcript_files);
+    }
+
+    conn.execute_batch("COMMIT").map_err(|e| e.to_string())?;
+    Ok(!skipped_remaining)
+}
+
+fn ingest_antigravity_file(
+    conn: &Connection,
+    path: &Path,
+    history: &std::collections::HashMap<String, String>,
+) -> Result<(), String> {
+    let path_str = path.to_string_lossy().to_string();
+    let meta = fs::metadata(path).map_err(|e| e.to_string())?;
+    let file_size = meta.len() as i64;
+    let mtime = file_mtime(&meta);
+
+    if let Some((size, _, mt)) = get_cursor(conn, &path_str) {
+        if size == file_size && mt == mtime {
+            return Ok(());
+        }
+    }
+
+    let session_id = antigravity_session_id(path).unwrap_or_else(|| {
+        path.parent()
+            .and_then(Path::parent)
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    });
+    let project = history
+        .get(&session_id)
+        .map(|workspace| project_name_from_path(workspace))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let file = fs::File::open(path).map_err(|e| e.to_string())?;
+    let reader = BufReader::new(file);
+    let mut input = 0_u64;
+    let mut output = 0_u64;
+    let mut model = "unknown".to_string();
+    let mut timestamp = 0_u64;
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => continue,
+        };
+        let row: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+
+        if let Some(ts) = row
+            .get("created_at")
+            .and_then(Value::as_str)
+            .and_then(parse_iso_timestamp)
+        {
+            timestamp = ts;
+        }
+
+        let source = row.get("source").and_then(Value::as_str).unwrap_or_default();
+        let step_type = row.get("type").and_then(Value::as_str).unwrap_or_default();
+        let content = row.get("content").and_then(Value::as_str).unwrap_or_default();
+
+        if step_type == "USER_INPUT" || source == "USER_EXPLICIT" {
+            input = input.saturating_add(estimate_text_tokens(content));
+            if let Some(selected) = extract_antigravity_model_selection(content) {
+                model = selected;
+            }
+        } else if source == "MODEL" && step_type == "PLANNER_RESPONSE" {
+            output = output.saturating_add(estimate_text_tokens(content));
+            if let Some(thinking) = row.get("thinking").and_then(Value::as_str) {
+                output = output.saturating_add(estimate_text_tokens(thinking));
+            }
+            if let Some(tool_calls) = row.get("tool_calls") {
+                output = output.saturating_add(estimate_text_tokens(&tool_calls.to_string()));
+            }
+        }
+    }
+
+    let total = input + output;
+    if total == 0 {
+        upsert_cursor(conn, &path_str, "antigravity", file_size, file_size, mtime)?;
+        return Ok(());
+    }
+    let pricing_provider = antigravity_pricing_provider(&model);
+
+    conn.execute(
+        "DELETE FROM usage_messages WHERE provider = 'antigravity' AND session_id = ?1",
+        params![session_id],
+    )
+    .map_err(|e| e.to_string())?;
+
+    conn.execute(
+        "INSERT INTO usage_messages (
+            provider, session_id, project, model, timestamp,
+            tokens_input, tokens_output, tokens_cache_write, tokens_cache_read,
+            tokens_thoughts, tokens_total, pricing_provider
+         ) VALUES (
+            'antigravity', ?1, ?2, ?3, ?4,
+            ?5, ?6, 0, 0,
+            0, ?7, ?8
+         )",
+        params![
+            session_id,
+            project,
+            model,
+            timestamp as i64,
+            input as i64,
+            output as i64,
+            total as i64,
+            pricing_provider,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+
+    upsert_cursor(conn, &path_str, "antigravity", file_size, file_size, mtime)?;
+    Ok(())
+}
+
+fn antigravity_pricing_provider(model: &str) -> &'static str {
+    let lower = model.to_ascii_lowercase();
+    if lower.contains("gemini") {
+        "google"
+    } else if lower.contains("claude") {
+        "anthropic"
+    } else {
+        "antigravity"
+    }
+}
+
+fn antigravity_session_id(path: &Path) -> Option<String> {
+    path.parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(ToString::to_string)
+}
+
+fn read_antigravity_history() -> std::collections::HashMap<String, String> {
+    let mut sessions = std::collections::HashMap::new();
+    let Ok(path) = home_join(".gemini/antigravity-cli/history.jsonl") else {
+        return sessions;
+    };
+    let Ok(file) = fs::File::open(path) else {
+        return sessions;
+    };
+    let reader = BufReader::new(file);
+    for line in reader.lines().map_while(Result::ok) {
+        let Ok(row) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(session_id) = row.get("conversationId").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(workspace) = row.get("workspace").and_then(Value::as_str) else {
+            continue;
+        };
+        sessions.insert(session_id.to_string(), workspace.to_string());
+    }
+    sessions
+}
+
+fn extract_antigravity_model_selection(content: &str) -> Option<String> {
+    let marker = "Model Selection` from ";
+    let start = content.find(marker)?;
+    let selected = &content[start + marker.len()..];
+    let (_, after_to) = selected.split_once(" to ")?;
+    let model = after_to
+        .split(". No need")
+        .next()
+        .unwrap_or(after_to)
+        .split('\n')
+        .next()
+        .unwrap_or(after_to)
+        .trim()
+        .trim_matches('`')
+        .trim();
+    if model.is_empty() || model == "None" {
+        None
+    } else {
+        Some(model.to_string())
+    }
+}
+
+fn estimate_text_tokens(text: &str) -> u64 {
+    let chars = text.chars().count() as u64;
+    if chars == 0 {
+        0
+    } else {
+        (chars + 3) / 4
+    }
+}
+
+fn project_name_from_path(path: &str) -> String {
+    path.rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 // ── Codex ─────────────────────────────────────────────────
@@ -1095,5 +1371,12 @@ mod tests {
 
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn antigravity_pricing_provider_uses_underlying_model_vendor() {
+        assert_eq!(antigravity_pricing_provider("Gemini 3.5 Flash (Medium)"), "google");
+        assert_eq!(antigravity_pricing_provider("Claude Sonnet 4.6 (Thinking)"), "anthropic");
+        assert_eq!(antigravity_pricing_provider("GPT-OSS 120B"), "antigravity");
     }
 }

--- a/src-tauri/src/usage/mod.rs
+++ b/src-tauri/src/usage/mod.rs
@@ -86,18 +86,21 @@ enum ProviderCacheData {
     Claude(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>),
     Codex(Vec<UsageWindowSnapshot>),
     Gemini(Vec<UsageWindowSnapshot>),
+    Antigravity(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>),
 }
 
 struct ProviderCache {
     claude: ProviderState,
     codex: ProviderState,
     gemini: ProviderState,
+    antigravity: ProviderState,
 }
 
 static PROVIDER_CACHE: Mutex<ProviderCache> = Mutex::new(ProviderCache {
     claude: ProviderState::new(),
     codex: ProviderState::new(),
     gemini: ProviderState::new(),
+    antigravity: ProviderState::new(),
 });
 
 /// Which providers are enabled (passed from frontend settings).
@@ -105,6 +108,7 @@ pub struct EnabledProviders {
     pub claude: bool,
     pub codex: bool,
     pub gemini: bool,
+    pub antigravity: bool,
 }
 
 /// Fetch snapshots for all providers from whatever is currently in the DB.
@@ -119,6 +123,7 @@ pub fn get_all_usage_snapshots(db: &UsageDb, enabled: &EnabledProviders) -> Vec<
         claude_snapshot(&conn),
         codex_snapshot(&conn),
         gemini_snapshot(&conn),
+        antigravity_snapshot(&conn),
         opencode_snapshot(&conn),
         pi_snapshot(&conn),
     ]
@@ -133,6 +138,7 @@ pub fn get_usage_snapshot(db: &UsageDb, provider: &str, enabled: &EnabledProvide
         "codex" => Ok(codex_snapshot(&conn)),
         "claude" => Ok(claude_snapshot(&conn)),
         "gemini" => Ok(gemini_snapshot(&conn)),
+        "antigravity" => Ok(antigravity_snapshot(&conn)),
         "opencode" => Ok(opencode_snapshot(&conn)),
         "pi" => Ok(pi_snapshot(&conn)),
         other => Err(format!("Unsupported usage provider: {other}")),
@@ -186,16 +192,17 @@ static PROVIDER_REFRESH_RUNNING: AtomicBool = AtomicBool::new(false);
 /// elapsed. Returns immediately — never blocks the calling thread on network I/O.
 fn spawn_provider_refresh(enabled: &EnabledProviders) {
     let now = now_epoch_seconds();
-    let (refresh_claude, refresh_codex, refresh_gemini) = {
+    let (refresh_claude, refresh_codex, refresh_gemini, refresh_antigravity) = {
         let cache = PROVIDER_CACHE.lock().unwrap();
         (
             enabled.claude && cache.claude.is_stale(now),
             enabled.codex && cache.codex.is_stale(now),
             enabled.gemini && cache.gemini.is_stale(now),
+            enabled.antigravity && cache.antigravity.is_stale(now),
         )
     };
 
-    if !refresh_claude && !refresh_codex && !refresh_gemini {
+    if !refresh_claude && !refresh_codex && !refresh_gemini && !refresh_antigravity {
         return;
     }
 
@@ -207,14 +214,15 @@ fn spawn_provider_refresh(enabled: &EnabledProviders) {
     let do_claude = refresh_claude;
     let do_codex = refresh_codex;
     let do_gemini = refresh_gemini;
+    let do_antigravity = refresh_antigravity;
     std::thread::spawn(move || {
-        refresh_provider_cache_sync(do_claude, do_codex, do_gemini);
+        refresh_provider_cache_sync(do_claude, do_codex, do_gemini, do_antigravity);
         PROVIDER_REFRESH_RUNNING.store(false, Ordering::SeqCst);
     });
 }
 
 /// Actual (blocking) provider refresh — only called from background thread.
-fn refresh_provider_cache_sync(do_claude: bool, do_codex: bool, do_gemini: bool) {
+fn refresh_provider_cache_sync(do_claude: bool, do_codex: bool, do_gemini: bool, do_antigravity: bool) {
     let now = now_epoch_seconds();
 
     if do_claude {
@@ -266,6 +274,24 @@ fn refresh_provider_cache_sync(do_claude: bool, do_codex: bool, do_gemini: bool)
                 cache.gemini.record_error(now, &e);
                 if should_log {
                     eprintln!("Gemini provider API error (using cache): {e}");
+                }
+            }
+        }
+    }
+
+    if do_antigravity {
+        match providers::antigravity_provider_windows() {
+            Ok(data) => {
+                let mut cache = PROVIDER_CACHE.lock().unwrap();
+                cache.antigravity.cache = Some(ProviderCacheData::Antigravity(data.0, data.1));
+                cache.antigravity.record_success(now);
+            }
+            Err(e) => {
+                let mut cache = PROVIDER_CACHE.lock().unwrap();
+                let should_log = cache.antigravity.should_log_error() || cache.antigravity.last_error != e;
+                cache.antigravity.record_error(now, &e);
+                if should_log {
+                    eprintln!("Antigravity provider API error (using cache): {e}");
                 }
             }
         }
@@ -417,6 +443,60 @@ fn gemini_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
         extra_windows: Vec::new(),
         local_details: local,
         error: None,
+    }
+}
+
+fn antigravity_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
+    let fetched_at = helpers::now_iso_string();
+    let local = queries::local_details(conn, "antigravity");
+    let cache = PROVIDER_CACHE.lock().unwrap();
+    let cached_data: Option<(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>)> = match &cache.antigravity.cache {
+        Some(ProviderCacheData::Antigravity(summary, extra)) => Some((summary.clone(), extra.clone())),
+        _ => None,
+    };
+    let error = if cached_data.is_none() && !cache.antigravity.last_error.is_empty() {
+        Some(cache.antigravity.last_error.clone())
+    } else {
+        None
+    };
+    drop(cache);
+
+    let (mut summary_windows, extra_windows, status) = match cached_data {
+        Some((summary, extra)) => (summary, extra, "ready".to_string()),
+        None if local.is_some() => (Vec::new(), Vec::new(), "partial".to_string()),
+        None => (Vec::new(), Vec::new(), "unavailable".to_string()),
+    };
+
+    if let Some(ref details) = local {
+        for (window, tokens) in [("5h", details.tokens_5h), ("7d", details.tokens_7d), ("30d", details.tokens_30d)] {
+            summary_windows.push(UsageWindowSnapshot {
+                provider: "antigravity".to_string(),
+                window_id: format!("antigravity-local-{window}"),
+                window: window.to_string(),
+                label: window.to_string(),
+                scope: "reporting".to_string(),
+                limit: None,
+                used: None,
+                source_type: "local".to_string(),
+                confidence: "estimated".to_string(),
+                cost_kind: "unknown".to_string(),
+                used_percent: None,
+                remaining_percent: None,
+                reset_at: None,
+                token_total: Some(tokens),
+                pace_status: None,
+            });
+        }
+    }
+
+    ProviderUsageSnapshot {
+        provider: "antigravity".to_string(),
+        status,
+        fetched_at,
+        summary_windows,
+        extra_windows,
+        local_details: local,
+        error,
     }
 }
 

--- a/src-tauri/src/usage/providers.rs
+++ b/src-tauri/src/usage/providers.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
-use std::fs;
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
 
 use super::helpers::{home_join, run_command};
 use super::types::UsageWindowSnapshot;
@@ -135,6 +137,498 @@ fn percent_window(provider: &str, label: &str, value: &Value) -> UsageWindowSnap
         token_total: None,
         pace_status: None,
     }
+}
+
+// ── Antigravity ───────────────────────────────────────────
+
+struct AntigravityProcess {
+    pid: i64,
+    csrf_token: String,
+    extension_port: Option<i64>,
+    extension_csrf_token: Option<String>,
+}
+
+struct AntigravityEndpoint {
+    scheme: &'static str,
+    port: i64,
+    csrf_token: String,
+}
+
+struct AntigravityQuota {
+    label: String,
+    model_id: String,
+    remaining_fraction: f64,
+    reset_time: Option<String>,
+}
+
+pub fn antigravity_provider_windows() -> Result<(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>), String> {
+    let process = antigravity_detect_process()?;
+    let ports = antigravity_listening_ports(process.pid)?;
+    let endpoints = antigravity_endpoints(&process, &ports);
+    if endpoints.is_empty() {
+        return Err("Antigravity language server has no detectable API port".to_string());
+    }
+
+    let quotas = antigravity_fetch_quotas(&endpoints)?;
+    antigravity_quotas_to_windows(&quotas)
+}
+
+fn antigravity_detect_process() -> Result<AntigravityProcess, String> {
+    let output = antigravity_process_list()?;
+    let mut saw_tokenless_ide = false;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some((pid_raw, command)) = trimmed.split_once(char::is_whitespace) else {
+            continue;
+        };
+        let Ok(pid) = pid_raw.trim().parse::<i64>() else {
+            continue;
+        };
+        let command = command.trim();
+        let Some(kind) = antigravity_process_kind(command) else {
+            continue;
+        };
+        let csrf_token = match extract_flag("--csrf_token", command) {
+            Some(token) => token,
+            None if kind == "cli" => String::new(),
+            None => {
+                saw_tokenless_ide = true;
+                continue;
+            }
+        };
+        return Ok(AntigravityProcess {
+            pid,
+            csrf_token,
+            extension_port: extract_flag("--extension_server_port", command)
+                .and_then(|value| value.parse::<i64>().ok()),
+            extension_csrf_token: extract_flag("--extension_server_csrf_token", command),
+        });
+    }
+
+    if saw_tokenless_ide {
+        Err("Antigravity language server is missing a CSRF token".to_string())
+    } else {
+        Err("Antigravity language server not detected. Launch Antigravity or agy and retry.".to_string())
+    }
+}
+
+fn antigravity_process_list() -> Result<String, String> {
+    let output = Command::new("/bin/ps")
+        .args(["-ax", "-o", "pid=,command="])
+        .output()
+        .map_err(|e| format!("Failed to run /bin/ps: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "/bin/ps exited with status {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    String::from_utf8(output.stdout)
+        .map(|s| s.trim().to_string())
+        .map_err(|e| format!("Invalid UTF-8 from /bin/ps: {e}"))
+}
+
+fn antigravity_process_kind(command: &str) -> Option<&'static str> {
+    let lower = command.to_lowercase();
+    if is_antigravity_ide_language_server(&lower) {
+        return Some("ide");
+    }
+    if is_antigravity_cli_command(&lower) {
+        return Some("cli");
+    }
+    None
+}
+
+fn is_antigravity_ide_language_server(lower: &str) -> bool {
+    (lower.contains("/language_server") || lower.contains("\\language_server"))
+        && (lower.contains("--app_data_dir") && lower.contains("antigravity")
+            || lower.contains("/antigravity/")
+            || lower.contains("\\antigravity\\"))
+}
+
+fn is_antigravity_cli_command(lower: &str) -> bool {
+    command_contains_program(lower, "agy")
+        || command_contains_program(lower, "antigravity-cli")
+        || command_contains_program(lower, "antigravity_cli")
+}
+
+fn command_contains_program(command: &str, program: &str) -> bool {
+    command == program
+        || command.starts_with(&format!("{program} "))
+        || command.contains(&format!(" {program} "))
+        || command.ends_with(&format!("/{program}"))
+        || command.contains(&format!("/{program} "))
+        || command.ends_with(&format!("\\{program}"))
+        || command.contains(&format!("\\{program} "))
+}
+
+fn extract_flag(flag: &str, command: &str) -> Option<String> {
+    let bytes = command.as_bytes();
+    let flag_bytes = flag.as_bytes();
+    let mut index = 0;
+    while index + flag_bytes.len() <= bytes.len() {
+        if &bytes[index..index + flag_bytes.len()] == flag_bytes {
+            let mut value_start = index + flag_bytes.len();
+            while value_start < bytes.len() && (bytes[value_start] == b'=' || bytes[value_start].is_ascii_whitespace()) {
+                value_start += 1;
+            }
+            if value_start >= bytes.len() {
+                return None;
+            }
+            let mut value_end = value_start;
+            while value_end < bytes.len() && !bytes[value_end].is_ascii_whitespace() {
+                value_end += 1;
+            }
+            return Some(command[value_start..value_end].to_string());
+        }
+        index += 1;
+    }
+    None
+}
+
+fn antigravity_listening_ports(pid: i64) -> Result<Vec<i64>, String> {
+    let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"]
+        .into_iter()
+        .find(|path| Path::new(path).exists())
+        .ok_or_else(|| "lsof not available".to_string())?;
+    let output = run_command(lsof, &["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", &pid.to_string()])?;
+    let mut ports = Vec::new();
+    for line in output.lines() {
+        if !line.contains("(LISTEN)") {
+            continue;
+        }
+        let Some(colon) = line.rfind(':') else {
+            continue;
+        };
+        let rest = &line[colon + 1..];
+        let port_raw: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        let Ok(port) = port_raw.parse::<i64>() else {
+            continue;
+        };
+        if !ports.contains(&port) {
+            ports.push(port);
+        }
+    }
+    ports.sort_unstable();
+    if ports.is_empty() {
+        Err("No Antigravity listening ports found".to_string())
+    } else {
+        Ok(ports)
+    }
+}
+
+fn antigravity_endpoints(process: &AntigravityProcess, ports: &[i64]) -> Vec<AntigravityEndpoint> {
+    let mut endpoints = Vec::new();
+    for port in ports {
+        endpoints.push(AntigravityEndpoint {
+            scheme: "https",
+            port: *port,
+            csrf_token: process.csrf_token.clone(),
+        });
+    }
+    if let Some(port) = process.extension_port {
+        if let Some(token) = &process.extension_csrf_token {
+            endpoints.push(AntigravityEndpoint {
+                scheme: "http",
+                port,
+                csrf_token: token.clone(),
+            });
+        }
+        if process.extension_csrf_token.as_deref() != Some(process.csrf_token.as_str()) {
+            endpoints.push(AntigravityEndpoint {
+                scheme: "http",
+                port,
+                csrf_token: process.csrf_token.clone(),
+            });
+        }
+    }
+    endpoints
+}
+
+fn antigravity_fetch_quotas(endpoints: &[AntigravityEndpoint]) -> Result<Vec<AntigravityQuota>, String> {
+    let mut last_error = "No Antigravity endpoint available".to_string();
+    for endpoint in endpoints {
+        for path in [
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+            "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs",
+        ] {
+            match antigravity_request(endpoint, path).and_then(|body| antigravity_parse_quotas(&body)) {
+                Ok(quotas) if !quotas.is_empty() => return Ok(quotas),
+                Ok(_) => last_error = "Antigravity returned no quota models".to_string(),
+                Err(error) => last_error = error,
+            }
+        }
+    }
+    Err(last_error)
+}
+
+fn antigravity_request(endpoint: &AntigravityEndpoint, path: &str) -> Result<String, String> {
+    let url = format!("{}://127.0.0.1:{}{}", endpoint.scheme, endpoint.port, path);
+    let csrf_header = format!("X-Codeium-Csrf-Token: {}", endpoint.csrf_token);
+    let body = r#"{"metadata":{"ideName":"antigravity","extensionName":"antigravity","ideVersion":"unknown","locale":"en"}}"#;
+    run_command(
+        "curl",
+        &[
+            "-skS",
+            "--max-time",
+            "8",
+            "--connect-timeout",
+            "2",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-H",
+            "Connect-Protocol-Version: 1",
+            "-H",
+            &csrf_header,
+            "-d",
+            body,
+            &url,
+        ],
+    )
+}
+
+fn antigravity_parse_quotas(body: &str) -> Result<Vec<AntigravityQuota>, String> {
+    let json: Value = serde_json::from_str(body)
+        .map_err(|e| format!("Failed to parse Antigravity response: {e}"))?;
+
+    if let Some(code) = json.get("code") {
+        let text = code
+            .as_str()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| code.to_string());
+        let normalized = text.trim_matches('"').to_lowercase();
+        if !normalized.is_empty() && normalized != "ok" && normalized != "success" && normalized != "0" {
+            return Err(format!("Antigravity API returned code {text}"));
+        }
+    }
+
+    let model_configs = json
+        .pointer("/userStatus/cascadeModelConfigData/clientModelConfigs")
+        .and_then(Value::as_array)
+        .or_else(|| json.get("clientModelConfigs").and_then(Value::as_array))
+        .ok_or_else(|| "Antigravity response missing model configs".to_string())?;
+
+    let mut quotas = Vec::new();
+    for config in model_configs {
+        let Some(quota) = config.get("quotaInfo") else {
+            continue;
+        };
+        let Some(remaining_fraction) = quota.get("remainingFraction").and_then(Value::as_f64) else {
+            continue;
+        };
+        let model_id = config
+            .pointer("/modelOrAlias/model")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let label = config
+            .get("label")
+            .and_then(Value::as_str)
+            .unwrap_or(&model_id)
+            .to_string();
+        let reset_time = quota.get("resetTime").and_then(Value::as_str).map(ToString::to_string);
+        quotas.push(AntigravityQuota {
+            label,
+            model_id,
+            remaining_fraction,
+            reset_time,
+        });
+    }
+
+    Ok(quotas)
+}
+
+fn antigravity_quotas_to_windows(quotas: &[AntigravityQuota]) -> Result<(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>), String> {
+    let mut summary = Vec::new();
+    let families = [
+        ("claude", "24h_claude", "Claude quota"),
+        ("gemini_pro", "24h_gemini_pro", "Gemini Pro quota"),
+        ("gemini_flash", "24h_gemini_flash", "Gemini Flash quota"),
+    ];
+
+    for (family, window, label) in families {
+        if let Some(quota) = quotas
+            .iter()
+            .filter(|quota| antigravity_model_family(quota) == family)
+            .min_by(|a, b| a.remaining_fraction.total_cmp(&b.remaining_fraction))
+        {
+            summary.push(antigravity_window(
+                &format!("antigravity-{window}"),
+                window,
+                label,
+                quota,
+            ));
+        }
+    }
+
+    if summary.is_empty() {
+        if let Some(quota) = quotas
+            .iter()
+            .min_by(|a, b| a.remaining_fraction.total_cmp(&b.remaining_fraction))
+        {
+            summary.push(antigravity_window(
+                "antigravity-quota",
+                "quota",
+                &quota.label,
+                quota,
+            ));
+        }
+    }
+
+    let mut extra: Vec<_> = quotas
+        .iter()
+        .map(|quota| {
+            antigravity_window(
+                &format!("antigravity-model-{}", sanitize_window_id(&quota.model_id)),
+                &sanitize_window_id(&quota.model_id),
+                &quota.label,
+                quota,
+            )
+        })
+        .collect();
+    extra.sort_by(|a, b| a.label.cmp(&b.label));
+
+    if summary.is_empty() {
+        return Err("No Antigravity quota windows could be derived".to_string());
+    }
+
+    Ok((summary, extra))
+}
+
+fn antigravity_model_family(quota: &AntigravityQuota) -> &'static str {
+    let text = format!("{} {}", quota.label, quota.model_id).to_lowercase();
+    if text.contains("claude") {
+        "claude"
+    } else if text.contains("gemini") && text.contains("pro") && !text.contains("flash") {
+        "gemini_pro"
+    } else if text.contains("gemini") && text.contains("flash") {
+        "gemini_flash"
+    } else {
+        "other"
+    }
+}
+
+fn antigravity_window(
+    window_id: &str,
+    window: &str,
+    label: &str,
+    quota: &AntigravityQuota,
+) -> UsageWindowSnapshot {
+    let remaining = (quota.remaining_fraction * 100.0).clamp(0.0, 100.0);
+    let used = (100.0 - remaining).max(0.0);
+    UsageWindowSnapshot {
+        provider: "antigravity".to_string(),
+        window_id: window_id.to_string(),
+        window: window.to_string(),
+        label: label.to_string(),
+        scope: "plan".to_string(),
+        limit: Some(100.0),
+        used: Some(used),
+        source_type: "provider".to_string(),
+        confidence: "official".to_string(),
+        cost_kind: "included".to_string(),
+        used_percent: Some(used),
+        remaining_percent: Some(remaining),
+        reset_at: quota.reset_time.clone(),
+        token_total: None,
+        pace_status: None,
+    }
+}
+
+fn sanitize_window_id(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch.to_ascii_lowercase() } else { '-' })
+        .collect();
+    sanitized.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn antigravity_process_kind_matches_cli_commands() {
+        assert_eq!(antigravity_process_kind("agy --model gemini"), Some("cli"));
+        assert_eq!(antigravity_process_kind("/usr/local/bin/antigravity-cli serve"), Some("cli"));
+        assert_eq!(antigravity_process_kind("/opt/bin/antigravity_cli"), Some("cli"));
+        assert_eq!(antigravity_process_kind("/usr/bin/env agy --dangerously-skip-permissions"), Some("cli"));
+    }
+
+    #[test]
+    fn antigravity_process_kind_matches_ide_language_server() {
+        let command = "/Applications/Antigravity.app/Contents/Resources/app/bin/language_server --app_data_dir /Users/me/Library/Application Support/Antigravity --csrf_token token";
+        assert_eq!(antigravity_process_kind(command), Some("ide"));
+    }
+
+    #[test]
+    fn extract_flag_accepts_space_and_equals_forms() {
+        assert_eq!(extract_flag("--csrf_token", "language_server --csrf_token abc123"), Some("abc123".to_string()));
+        assert_eq!(extract_flag("--csrf_token", "language_server --csrf_token=abc123"), Some("abc123".to_string()));
+        assert_eq!(extract_flag("--csrf_token", "language_server --other abc123"), None);
+    }
+
+    #[test]
+    fn antigravity_parse_quotas_reads_user_status_shape() {
+        let body = r#"{
+            "code": "success",
+            "userStatus": {
+                "cascadeModelConfigData": {
+                    "clientModelConfigs": [
+                        {
+                            "label": "Claude Sonnet 4.5",
+                            "modelOrAlias": { "model": "claude-sonnet-4-5" },
+                            "quotaInfo": { "remainingFraction": 0.42, "resetTime": "2026-06-10T12:00:00Z" }
+                        },
+                        {
+                            "label": "Gemini 3 Pro",
+                            "modelOrAlias": { "model": "gemini-3-pro" }
+                        }
+                    ]
+                }
+            }
+        }"#;
+
+        let quotas = antigravity_parse_quotas(body).expect("quotas");
+        assert_eq!(quotas.len(), 1);
+        assert_eq!(quotas[0].label, "Claude Sonnet 4.5");
+        assert_eq!(quotas[0].model_id, "claude-sonnet-4-5");
+        assert_eq!(quotas[0].remaining_fraction, 0.42);
+        assert_eq!(quotas[0].reset_time.as_deref(), Some("2026-06-10T12:00:00Z"));
+    }
+
+    #[test]
+    fn antigravity_windows_use_24h_summary_names() {
+        let quotas = vec![
+            AntigravityQuota {
+                label: "Claude Sonnet 4.5".to_string(),
+                model_id: "claude-sonnet-4-5".to_string(),
+                remaining_fraction: 0.5,
+                reset_time: None,
+            },
+            AntigravityQuota {
+                label: "Gemini 3 Pro".to_string(),
+                model_id: "gemini-3-pro".to_string(),
+                remaining_fraction: 0.75,
+                reset_time: None,
+            },
+        ];
+
+        let (summary, extra) = antigravity_quotas_to_windows(&quotas).expect("windows");
+        assert_eq!(summary[0].window, "24h_claude");
+        assert_eq!(summary[1].window, "24h_gemini_pro");
+        assert_eq!(summary[0].used_percent, Some(50.0));
+        assert_eq!(summary[1].remaining_percent, Some(75.0));
+        assert_eq!(extra.len(), 2);
+    }
+
 }
 
 // ── Gemini ────────────────────────────────────────────────

--- a/src-tauri/src/usage/queries.rs
+++ b/src-tauri/src/usage/queries.rs
@@ -56,20 +56,80 @@ fn load_pricing(conn: &Connection) -> PricingMap {
 
 /// Match a model name to a pricing pattern (prefix match).
 fn find_pricing<'a>(provider: &str, model: &str, pricing: &'a PricingMap) -> Option<&'a ModelPricing> {
-    if let Some(p) = pricing.get(&(provider.to_string(), model.to_string())) {
-        return Some(p);
-    }
+    let aliases = pricing_model_aliases(model);
     let mut best_match: Option<(&str, &ModelPricing)> = None;
-    for ((pricing_provider, pattern), p) in pricing {
-        if pricing_provider == provider && model.starts_with(pattern.as_str()) {
-            match best_match {
-                Some((prev, _)) if pattern.len() > prev.len() => best_match = Some((pattern, p)),
-                None => best_match = Some((pattern, p)),
-                _ => {}
+    for alias in aliases {
+        if let Some(p) = pricing.get(&(provider.to_string(), alias.clone())) {
+            return Some(p);
+        }
+        for ((pricing_provider, pattern), p) in pricing {
+            if pricing_provider == provider && alias.starts_with(pattern.as_str()) {
+                match best_match {
+                    Some((prev, _)) if pattern.len() > prev.len() => best_match = Some((pattern, p)),
+                    None => best_match = Some((pattern, p)),
+                    _ => {}
+                }
             }
         }
     }
     best_match.map(|(_, p)| p)
+}
+
+fn pricing_model_aliases(model: &str) -> Vec<String> {
+    let mut aliases = vec![model.to_string()];
+    let lower = model.to_ascii_lowercase();
+
+    if lower.contains("gemini 3.5 flash") {
+        aliases.push("gemini-3.5-flash".to_string());
+    } else if lower.contains("gemini 3.1 pro") {
+        aliases.push("gemini-3.1-pro-preview".to_string());
+    } else if lower.contains("gemini 3.1 flash") && lower.contains("image") {
+        aliases.push("gemini-3.1-flash-image-preview".to_string());
+    } else if lower.contains("gemini 3.1 flash") {
+        aliases.push("gemini-3.1-flash-lite".to_string());
+    } else if lower.contains("gemini 3 pro") && lower.contains("image") {
+        aliases.push("gemini-3-pro-image-preview".to_string());
+    } else if lower.contains("gemini 3 pro") {
+        aliases.push("gemini-3-pro-preview".to_string());
+    } else if lower.contains("gemini 3 flash") {
+        aliases.push("gemini-3-flash-preview".to_string());
+    } else if lower.contains("gemini 2.5 pro") {
+        aliases.push("gemini-2.5-pro".to_string());
+    } else if lower.contains("gemini 2.5 flash") && lower.contains("lite") {
+        aliases.push("gemini-2.5-flash-lite".to_string());
+    } else if lower.contains("gemini 2.5 flash") {
+        aliases.push("gemini-2.5-flash".to_string());
+    } else if lower.contains("gemini 2.0 flash") && lower.contains("lite") {
+        aliases.push("gemini-2.0-flash-lite".to_string());
+    } else if lower.contains("gemini 2.0 flash") {
+        aliases.push("gemini-2.0-flash".to_string());
+    }
+
+    if lower.contains("claude sonnet 4.6") {
+        aliases.push("claude-sonnet-4-6".to_string());
+    } else if lower.contains("claude sonnet 4.5") {
+        aliases.push("claude-sonnet-4-5".to_string());
+    } else if lower.contains("claude sonnet 4") {
+        aliases.push("claude-sonnet-4-0".to_string());
+    } else if lower.contains("claude opus 4.8") {
+        aliases.push("claude-opus-4-8".to_string());
+    } else if lower.contains("claude opus 4.7") {
+        aliases.push("claude-opus-4-7".to_string());
+    } else if lower.contains("claude opus 4.6") {
+        aliases.push("claude-opus-4-6".to_string());
+    } else if lower.contains("claude opus 4.5") {
+        aliases.push("claude-opus-4-5".to_string());
+    } else if lower.contains("claude opus 4.1") {
+        aliases.push("claude-opus-4-1".to_string());
+    } else if lower.contains("claude opus 4") {
+        aliases.push("claude-opus-4-0".to_string());
+    } else if lower.contains("claude haiku 4.5") {
+        aliases.push("claude-haiku-4-5".to_string());
+    } else if lower.contains("claude fable 5") {
+        aliases.push("claude-fable-5".to_string());
+    }
+
+    aliases
 }
 
 /// Calculate cost in USD for a set of token counts.
@@ -1596,4 +1656,49 @@ pub fn models_for_provider(conn: &Connection, provider: &str) -> Vec<String> {
     };
 
     rows.filter_map(|r| r.ok()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model_pricing(input_per_m: f64, output_per_m: f64) -> ModelPricing {
+        ModelPricing {
+            input_per_m,
+            output_per_m,
+            cache_read_per_m: 0.0,
+            cache_write_per_m: 0.0,
+            thoughts_per_m: 0.0,
+        }
+    }
+
+    #[test]
+    fn find_pricing_maps_antigravity_gemini_labels() {
+        let mut pricing = PricingMap::new();
+        pricing.insert(
+            ("google".to_string(), "gemini-3.5-flash".to_string()),
+            model_pricing(1.5, 9.0),
+        );
+
+        let found = find_pricing("google", "Gemini 3.5 Flash (Medium)", &pricing)
+            .expect("pricing");
+
+        assert_eq!(found.input_per_m, 1.5);
+        assert_eq!(found.output_per_m, 9.0);
+    }
+
+    #[test]
+    fn find_pricing_maps_antigravity_claude_labels() {
+        let mut pricing = PricingMap::new();
+        pricing.insert(
+            ("anthropic".to_string(), "claude-sonnet-4-6".to_string()),
+            model_pricing(3.0, 15.0),
+        );
+
+        let found = find_pricing("anthropic", "Claude Sonnet 4.6 (Thinking)", &pricing)
+            .expect("pricing");
+
+        assert_eq!(found.input_per_m, 3.0);
+        assert_eq!(found.output_per_m, 15.0);
+    }
 }

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -52,12 +52,15 @@ pub struct EditorSettings {
 pub struct ProjectSettings {
     #[serde(default = "default_true", rename = "autoImportWorktrees")]
     pub auto_import_worktrees: bool,
+    #[serde(default = "default_true", rename = "showAgentSessionsInSidebar")]
+    pub show_agent_sessions_in_sidebar: bool,
 }
 
 impl Default for ProjectSettings {
     fn default() -> Self {
         ProjectSettings {
             auto_import_worktrees: true,
+            show_agent_sessions_in_sidebar: true,
         }
     }
 }

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -232,6 +232,8 @@ pub struct UsageSettings {
     #[serde(default = "default_provider_subscription")]
     pub codex: ProviderBudgetConfig,
     #[serde(default = "default_provider_subscription")]
+    pub antigravity: ProviderBudgetConfig,
+    #[serde(default = "default_provider_subscription")]
     pub gemini: ProviderBudgetConfig,
     #[serde(default = "default_provider_custom")]
     pub opencode: ProviderBudgetConfig,
@@ -244,6 +246,7 @@ impl Default for UsageSettings {
         UsageSettings {
             claude: ProviderBudgetConfig::default_subscription(),
             codex: ProviderBudgetConfig::default_subscription(),
+            antigravity: ProviderBudgetConfig::default_subscription(),
             gemini: ProviderBudgetConfig { show: false, ..ProviderBudgetConfig::default_subscription() },
             opencode: ProviderBudgetConfig {
                 monthly_budget: Some(100.0),

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -54,6 +54,8 @@ pub struct ProjectSettings {
     pub auto_import_worktrees: bool,
     #[serde(default = "default_true", rename = "showAgentSessionsInSidebar")]
     pub show_agent_sessions_in_sidebar: bool,
+    #[serde(default = "default_true", rename = "showTodos")]
+    pub show_todos: bool,
 }
 
 impl Default for ProjectSettings {
@@ -61,6 +63,7 @@ impl Default for ProjectSettings {
         ProjectSettings {
             auto_import_worktrees: true,
             show_agent_sessions_in_sidebar: true,
+            show_todos: true,
         }
     }
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -389,6 +389,20 @@ export default function AppShell() {
     }
   }, [setActiveTab, activeRepoPath]);
 
+  const handleSelectSidebarProjectTab = useCallback(async (repoPath: string, tabId: string) => {
+    useUIStore.getState().deactivateAllOverlays();
+    if (repoPath !== activeRepoPath) {
+      await handleSelectRepo(repoPath);
+    }
+
+    const store = useTerminalStore.getState();
+    store.setActiveTab(tabId);
+    const tab = store.projectState[repoPath]?.tabs.find((entry) => entry.id === tabId);
+    if (tab && (tab.kind === "terminal" || tab.kind === "assistant")) {
+      store.clearTabBell(tab.ptyId);
+    }
+  }, [activeRepoPath, handleSelectRepo]);
+
   const handleCloseTab = useCallback((tabId: string) => {
     const store = useTerminalStore.getState();
     const path = store.activeProjectPath;
@@ -645,6 +659,7 @@ export default function AppShell() {
             onNewAssistant={handleNewAssistant}
             onOpenInEditor={handleOpenInEditor}
             onSelectTab={handleSelectSidebarTab}
+            onSelectProjectTab={handleSelectSidebarProjectTab}
             onCloseTab={handleCloseTab}
             onNewShell={handleNewShell}
             onRenameGroup={handleRenameGroup}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -42,6 +42,7 @@ const SessionLauncher = lazy(() => import("../session/SessionLauncher"));
 const UsagePanel = lazy(() => import("../usage/UsagePanel"));
 const PortsPanel = lazy(() => import("../ports/PortsPanel"));
 const DiffSummaryPanel = lazy(() => import("../git/DiffSummaryPanel"));
+const TodosPanel = lazy(() => import("../todos/TodosPanel"));
 
 function toCommandConfig(command: CommandState): CommandConfig {
   return {
@@ -719,6 +720,11 @@ export default function AppShell() {
             {!showOverlay && activeTab?.kind === "launcher" && (
               <Suspense fallback={<PanelLoader />}>
                 <SessionLauncher onStartSession={handleStartSession} />
+              </Suspense>
+            )}
+            {!showOverlay && activeTab?.kind === "todos" && (
+              <Suspense fallback={<PanelLoader />}>
+                <TodosPanel />
               </Suspense>
             )}
 

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -370,7 +370,7 @@ export default function SettingsPanel() {
       <section className="settings-section">
         <h2 className="section-label !p-0 settings-section__header">Projects</h2>
 
-        <div className="settings-row !mb-0">
+        <div className="settings-row">
           <span className="settings-row__label flex items-center gap-2">
             <span>Auto-import Worktrees</span>
             <InfoTip text="When enabled, adding a main repo also imports its existing Git worktrees. Adding a worktree directly still adds its main repo so the relationship stays intact." />
@@ -380,6 +380,19 @@ export default function SettingsPanel() {
             className={`option-card option-card--compact ${projectSettings.autoImportWorktrees ? "selected" : ""}`}
           >
             {projectSettings.autoImportWorktrees ? "On" : "Off"}
+          </button>
+        </div>
+
+        <div className="settings-row !mb-0">
+          <span className="settings-row__label flex items-center gap-2">
+            <span>Agent Sessions in Sidebar</span>
+            <InfoTip text="Shows the global agent session section above Projects. Project tabs and agent sessions remain available inside each project when this is off." />
+          </span>
+          <button
+            onClick={() => void updateProjectSettings({ showAgentSessionsInSidebar: !projectSettings.showAgentSessionsInSidebar })}
+            className={`option-card option-card--compact ${projectSettings.showAgentSessionsInSidebar ? "selected" : ""}`}
+          >
+            {projectSettings.showAgentSessionsInSidebar ? "On" : "Off"}
           </button>
         </div>
 

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -8,6 +8,8 @@ import { useEditorStore } from "../../stores/useEditorStore";
 import { useThemeStore } from "../../stores/useThemeStore";
 import { useKeybindingStore } from "../../stores/useKeybindingStore";
 import { useProjectSettingsStore } from "../../stores/useProjectSettingsStore";
+import { useRepoStore } from "../../stores/useRepoStore";
+import { useTodoStore } from "../../stores/useTodoStore";
 import { useTerminalSettingsStore } from "../../stores/useTerminalSettingsStore";
 import { useUsageSettingsStore } from "../../stores/useUsageSettingsStore";
 import { useUpdateStore } from "../../stores/useUpdateStore";
@@ -383,7 +385,7 @@ export default function SettingsPanel() {
           </button>
         </div>
 
-        <div className="settings-row !mb-0">
+        <div className="settings-row">
           <span className="settings-row__label flex items-center gap-2">
             <span>Agent Sessions in Sidebar</span>
             <InfoTip text="Shows the global agent session section above Projects. Project tabs and agent sessions remain available inside each project when this is off." />
@@ -393,6 +395,26 @@ export default function SettingsPanel() {
             className={`option-card option-card--compact ${projectSettings.showAgentSessionsInSidebar ? "selected" : ""}`}
           >
             {projectSettings.showAgentSessionsInSidebar ? "On" : "Off"}
+          </button>
+        </div>
+
+        <div className="settings-row !mb-0">
+          <span className="settings-row__label flex items-center gap-2">
+            <span>Project To-dos</span>
+            <InfoTip text="Shows a To-dos row in each project that surfaces any TODO.md in the repo as a shared checklist for you and your coding agents. Turning this off hides the row and stops scanning for todo files." />
+          </span>
+          <button
+            onClick={() => {
+              const enabling = !projectSettings.showTodos;
+              void updateProjectSettings({ showTodos: enabling });
+              if (enabling) {
+                const repoPaths = useRepoStore.getState().repos.map((repo) => repo.path);
+                void useTodoStore.getState().refreshAll(repoPaths);
+              }
+            }}
+            className={`option-card option-card--compact ${projectSettings.showTodos ? "selected" : ""}`}
+          >
+            {projectSettings.showTodos ? "On" : "Off"}
           </button>
         </div>
 

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -548,11 +548,13 @@ export default function SettingsPanel() {
               ? "Claude"
               : provider === "codex"
                 ? "Codex"
-                : provider === "gemini"
-                  ? "Gemini"
-                  : provider === "opencode"
-                    ? "opencode"
-                    : "pi";
+                : provider === "antigravity"
+                  ? "Antigravity"
+                  : provider === "gemini"
+                    ? "Gemini"
+                    : provider === "opencode"
+                      ? "opencode"
+                      : "pi";
             const budgetInput = budgetInputs[provider] ?? (config.monthlyBudget != null ? String(config.monthlyBudget) : "");
             return (
               <div key={provider} className="usage-provider-row">

--- a/src/components/sidebar/ActivityIndicator.tsx
+++ b/src/components/sidebar/ActivityIndicator.tsx
@@ -1,0 +1,57 @@
+import type { TabActivity } from "../../lib/types";
+
+export type ActivityIndicatorStatus = "idle" | "running" | "active" | "attention" | "failed";
+
+export interface AggregateActivity {
+  hasAttention?: boolean;
+  hasCrash?: boolean;
+  hasActive?: boolean;
+  hasRunning?: boolean;
+}
+
+export function getTabActivityStatus(activity: TabActivity | undefined): ActivityIndicatorStatus {
+  if (!activity) return "idle";
+  if (!activity.alive) return activity.exitCode === 0 ? "idle" : "failed";
+  if (activity.bell) return "attention";
+  if (activity.active) return "active";
+  return "running";
+}
+
+export function getAggregateActivityStatus(activity: AggregateActivity | undefined): ActivityIndicatorStatus | null {
+  if (!activity) return null;
+  if (activity.hasCrash) return "failed";
+  if (activity.hasAttention) return "attention";
+  if (activity.hasActive) return "active";
+  if (activity.hasRunning) return "running";
+  return null;
+}
+
+function activityLabel(status: ActivityIndicatorStatus, activity?: TabActivity): string {
+  if (status === "failed") return activity?.exitCode == null ? "Failed" : `Failed with exit code ${activity.exitCode}`;
+  if (status === "attention") return activity?.lastNotificationMessage || "Needs attention";
+  if (status === "active") return "Active output";
+  if (status === "running") return "Running, quiet";
+  return "Idle";
+}
+
+interface ActivityIndicatorProps {
+  status: ActivityIndicatorStatus;
+  activity?: TabActivity;
+  className?: string;
+}
+
+export default function ActivityIndicator({
+  status,
+  activity,
+  className = "",
+}: ActivityIndicatorProps) {
+  const label = activityLabel(status, activity);
+
+  return (
+    <span
+      className={`activity-indicator activity-indicator--${status}${className ? ` ${className}` : ""}`}
+      title={label}
+      aria-label={label}
+    />
+  );
+}

--- a/src/components/sidebar/AgentSessionList.tsx
+++ b/src/components/sidebar/AgentSessionList.tsx
@@ -5,6 +5,7 @@ import { handleActionKey } from "../../lib/a11y";
 import { useTerminalStore } from "../../stores/useTerminalStore";
 import tabKindMeta from "../../lib/tabKindMeta";
 import SidebarSectionToggle from "./SidebarSectionToggle";
+import ActivityIndicator, { getTabActivityStatus } from "./ActivityIndicator";
 
 export interface AgentSessionItem {
   tab: TerminalTabData;
@@ -21,13 +22,6 @@ interface AgentSessionListProps {
 
 const MAX_VISIBLE_SESSIONS = 4;
 const COLLAPSED_STORAGE_KEY = "shep:sidebar-agent-sessions-collapsed";
-
-function dotClass(activity: TabActivity | undefined): string {
-  if (!activity) return "sidebar-status-dot--idle";
-  if (!activity.alive) return activity.exitCode === 0 ? "sidebar-status-dot--idle" : "sidebar-status-dot--exited";
-  if (activity.active) return "sidebar-status-dot--active";
-  return "sidebar-status-dot--idle";
-}
 
 function AgentSessionRow({
   item,
@@ -69,7 +63,11 @@ function AgentSessionRow({
         <span className="agent-session-row__project">{projectName}</span>
         {branchName && <span className="agent-session-row__branch">{branchName}</span>}
       </span>
-      <span className={`sidebar-status-dot agent-session-row__dot ${dotClass(activity)}`} />
+      <ActivityIndicator
+        status={getTabActivityStatus(activity)}
+        activity={activity}
+        className="agent-session-row__indicator"
+      />
     </div>
   );
 }

--- a/src/components/sidebar/AgentSessionList.tsx
+++ b/src/components/sidebar/AgentSessionList.tsx
@@ -98,7 +98,6 @@ export default function AgentSessionList({
     <div className="sidebar-section px-2 pb-1">
       <SidebarSectionToggle
         label="Agent Sessions"
-        icon={tabKindMeta.assistant.icon(14)}
         collapsed={collapsed}
         badge={sessions.length}
         onToggle={handleToggle}

--- a/src/components/sidebar/AgentSessionList.tsx
+++ b/src/components/sidebar/AgentSessionList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { TabActivity, TerminalTabData } from "../../lib/types";
 import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogos";
 import { handleActionKey } from "../../lib/a11y";
@@ -21,7 +21,6 @@ interface AgentSessionListProps {
 }
 
 const MAX_VISIBLE_SESSIONS = 4;
-const COLLAPSED_STORAGE_KEY = "shep:sidebar-agent-sessions-collapsed";
 
 function AgentSessionRow({
   item,
@@ -78,19 +77,14 @@ export default function AgentSessionList({
   activeTabId,
   onSelectSession,
 }: AgentSessionListProps) {
-  const [collapsed, setCollapsed] = useState(
-    () => window.localStorage.getItem(COLLAPSED_STORAGE_KEY) === "true",
-  );
+  // Always starts expanded on launch; collapsing is per-session only.
+  const [collapsed, setCollapsed] = useState(false);
   const visibleSessions = collapsed ? [] : sessions.slice(0, MAX_VISIBLE_SESSIONS);
   const overflowCount = Math.max(0, sessions.length - MAX_VISIBLE_SESSIONS);
 
   const handleToggle = useCallback(() => {
     setCollapsed((value) => !value);
   }, []);
-
-  useEffect(() => {
-    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, String(collapsed));
-  }, [collapsed]);
 
   if (sessions.length === 0) return null;
 

--- a/src/components/sidebar/AgentSessionList.tsx
+++ b/src/components/sidebar/AgentSessionList.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from "react";
+import type { TabActivity, TerminalTabData } from "../../lib/types";
+import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogos";
+import { handleActionKey } from "../../lib/a11y";
+import { useTerminalStore } from "../../stores/useTerminalStore";
+import tabKindMeta from "../../lib/tabKindMeta";
+import SidebarSectionToggle from "./SidebarSectionToggle";
+
+export interface AgentSessionItem {
+  tab: TerminalTabData;
+  projectName: string;
+  branchName: string | null;
+}
+
+interface AgentSessionListProps {
+  sessions: AgentSessionItem[];
+  activeRepoPath: string | null;
+  activeTabId: string | null;
+  onSelectSession: (repoPath: string, tabId: string) => void;
+}
+
+const MAX_VISIBLE_SESSIONS = 4;
+const COLLAPSED_STORAGE_KEY = "shep:sidebar-agent-sessions-collapsed";
+
+function dotClass(activity: TabActivity | undefined): string {
+  if (!activity) return "sidebar-status-dot--idle";
+  if (!activity.alive) return activity.exitCode === 0 ? "sidebar-status-dot--idle" : "sidebar-status-dot--exited";
+  if (activity.active) return "sidebar-status-dot--active";
+  return "sidebar-status-dot--idle";
+}
+
+function AgentSessionRow({
+  item,
+  isActive,
+  onSelect,
+}: {
+  item: AgentSessionItem;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  const { tab, projectName, branchName } = item;
+  const logoUrl = tab.assistantId ? assistantLogoSrc[tab.assistantId] : null;
+  const activity: TabActivity | undefined = useTerminalStore((s) => s.tabActivity[tab.ptyId]);
+  const title = branchName ? `${projectName} - ${branchName}` : projectName;
+
+  return (
+    <div
+      className={`list-item agent-session-row ${isActive ? "active" : ""}`}
+      onClick={onSelect}
+      onKeyDown={(event) => handleActionKey(event, onSelect)}
+      title={title}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isActive}
+      aria-label={`Open agent session in ${title}`}
+    >
+      {logoUrl ? (
+        <img
+          src={logoUrl}
+          alt=""
+          width={14}
+          height={14}
+          className={tab.assistantId ? getAssistantLogoClass(tab.assistantId) : undefined}
+        />
+      ) : (
+        <span className="shrink-0">{tabKindMeta.assistant.icon(14)}</span>
+      )}
+      <span className="agent-session-row__text">
+        <span className="agent-session-row__project">{projectName}</span>
+        {branchName && <span className="agent-session-row__branch">{branchName}</span>}
+      </span>
+      <span className={`sidebar-status-dot agent-session-row__dot ${dotClass(activity)}`} />
+    </div>
+  );
+}
+
+export default function AgentSessionList({
+  sessions,
+  activeRepoPath,
+  activeTabId,
+  onSelectSession,
+}: AgentSessionListProps) {
+  const [collapsed, setCollapsed] = useState(
+    () => window.localStorage.getItem(COLLAPSED_STORAGE_KEY) === "true",
+  );
+  const visibleSessions = collapsed ? [] : sessions.slice(0, MAX_VISIBLE_SESSIONS);
+  const overflowCount = Math.max(0, sessions.length - MAX_VISIBLE_SESSIONS);
+
+  const handleToggle = useCallback(() => {
+    setCollapsed((value) => !value);
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, String(collapsed));
+  }, [collapsed]);
+
+  if (sessions.length === 0) return null;
+
+  return (
+    <div className="sidebar-section px-2 pb-1">
+      <SidebarSectionToggle
+        label="Agent Sessions"
+        icon={tabKindMeta.assistant.icon(14)}
+        collapsed={collapsed}
+        badge={sessions.length}
+        onToggle={handleToggle}
+      />
+
+      {!collapsed && (
+        <div className="sidebar-section__list">
+          {visibleSessions.map((item) => (
+            <AgentSessionRow
+              key={`${item.tab.repoPath}:${item.tab.id}`}
+              item={item}
+              isActive={item.tab.repoPath === activeRepoPath && item.tab.id === activeTabId}
+              onSelect={() => onSelectSession(item.tab.repoPath, item.tab.id)}
+            />
+          ))}
+          {overflowCount > 0 && (
+            <div className="sidebar-section__overflow">+{overflowCount} more in projects</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/AssistantButton.tsx
+++ b/src/components/sidebar/AssistantButton.tsx
@@ -6,19 +6,13 @@ import { handleActionKey } from "../../lib/a11y";
 import { X } from "lucide-react";
 import ContextMenu from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
+import ActivityIndicator, { getTabActivityStatus } from "./ActivityIndicator";
 
 interface AssistantButtonProps {
   tab: TerminalTabData;
   isActive: boolean;
   onClick: () => void;
   onClose: () => void;
-}
-
-function dotClass(activity: TabActivity | undefined): string {
-  if (!activity) return "sidebar-status-dot--idle";
-  if (!activity.alive) return activity.exitCode === 0 ? "sidebar-status-dot--idle" : "sidebar-status-dot--exited";
-  if (activity.active) return "sidebar-status-dot--active";
-  return "sidebar-status-dot--idle";
 }
 
 export default function AssistantButton({
@@ -60,7 +54,7 @@ export default function AssistantButton({
       >
         {logoUrl && <img src={logoUrl} alt="" width={14} height={14} className={tab.assistantId ? getAssistantLogoClass(tab.assistantId) : undefined} />}
         <span className="truncate text-left">{tab.label}</span>
-        <span className={`sidebar-status-dot ${dotClass(activity)}`} />
+        <ActivityIndicator status={getTabActivityStatus(activity)} activity={activity} />
       </div>
       {menu && (
         <ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />

--- a/src/components/sidebar/GroupHeader.tsx
+++ b/src/components/sidebar/GroupHeader.tsx
@@ -4,11 +4,12 @@ import { createPortal } from "react-dom";
 import ContextMenu from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import type { RepoGroup } from "../../lib/types";
+import ActivityIndicator, { getAggregateActivityStatus } from "./ActivityIndicator";
 
 interface GroupHeaderProps {
   group: RepoGroup;
   isExpanded: boolean;
-  activity?: { hasAttention: boolean; hasCrash: boolean; hasActivity: boolean };
+  activity?: { hasAttention: boolean; hasCrash: boolean; hasActivity: boolean; hasActive: boolean };
   onToggle: () => void;
   onRename: (groupId: string, newName: string) => void;
   onDelete: (groupId: string) => void;
@@ -22,12 +23,12 @@ export default function GroupHeader({
   onRename,
   onDelete,
 }: GroupHeaderProps) {
-  const hasActivity = activity?.hasActivity ?? false;
-  const dotColor = activity?.hasCrash
-    ? "var(--status-crashed)"
-    : activity?.hasAttention
-      ? "var(--status-attention)"
-      : "var(--status-running)";
+  const activityStatus = getAggregateActivityStatus({
+    hasCrash: activity?.hasCrash,
+    hasAttention: activity?.hasAttention,
+    hasActive: activity?.hasActive,
+    hasRunning: activity?.hasActivity,
+  });
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(group.name);
@@ -120,8 +121,8 @@ export default function GroupHeader({
           <span className="group-header__name truncate">{group.name}</span>
         )}
         <span className="flex-1" />
-        {!isExpanded && hasActivity && (
-          <span className="sidebar-status-dot" style={{ background: dotColor }} />
+        {!isExpanded && activityStatus && (
+          <ActivityIndicator status={activityStatus} />
         )}
       </div>
       {menu &&

--- a/src/components/sidebar/ProjectItem.tsx
+++ b/src/components/sidebar/ProjectItem.tsx
@@ -19,12 +19,13 @@ import { useNoticeStore } from "../../stores/useNoticeStore";
 import { getErrorMessage } from "../../lib/errors";
 import { handleActionKey } from "../../lib/a11y";
 import { gitCreateWorktree, revealInFinder } from "../../lib/tauri";
+import ActivityIndicator, { getAggregateActivityStatus } from "./ActivityIndicator";
 
 interface ProjectItemProps {
   repo: RepoInfo;
   isActive: boolean;
   isExpanded: boolean;
-  activity?: { terminalCount: number; runningCount: number; hasAttention: boolean; hasCrash: boolean };
+  activity?: { terminalCount: number; runningCount: number; hasAttention: boolean; hasCrash: boolean; hasActive: boolean };
   worktreeParent?: string | null;
   groups: RepoGroup[];
   onClick: () => void;
@@ -49,12 +50,12 @@ export default function ProjectItem({
   onMoveToGroup,
   onNewGroupForRepo,
 }: ProjectItemProps) {
-  const hasActivity = activity && (activity.terminalCount > 0 || activity.runningCount > 0);
-  const dotColor = activity?.hasCrash
-    ? "var(--status-crashed)"
-    : activity?.hasAttention
-      ? "var(--status-attention)"
-      : "var(--status-running)";
+  const activityStatus = getAggregateActivityStatus({
+    hasCrash: activity?.hasCrash,
+    hasAttention: activity?.hasAttention,
+    hasActive: activity?.hasActive,
+    hasRunning: Boolean(activity && (activity.terminalCount > 0 || activity.runningCount > 0)),
+  });
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const preferredEditor = useEditorStore((s) => s.settings.preferredEditor);
   const pushNotice = useNoticeStore((s) => s.pushNotice);
@@ -242,8 +243,8 @@ export default function ProjectItem({
           {worktreeParent ? `${worktreeParent} > ${repo.name}` : repo.name}
         </span>
         <span className="flex-1" />
-        {!isExpanded && hasActivity && (
-          <span className="sidebar-status-dot" style={{ background: dotColor }} />
+        {!isExpanded && activityStatus && (
+          <ActivityIndicator status={activityStatus} />
         )}
       </div>
       {menu && createPortal(

--- a/src/components/sidebar/ProjectList.tsx
+++ b/src/components/sidebar/ProjectList.tsx
@@ -21,7 +21,7 @@ interface ProjectListProps {
   activeRepoPath: string | null;
   activeTabId: string | null;
   commands: CommandState[];
-  projectActivity: Record<string, { terminalCount: number; runningCount: number; hasAttention: boolean; hasCrash: boolean }>;
+  projectActivity: Record<string, { terminalCount: number; runningCount: number; hasAttention: boolean; hasCrash: boolean; hasActive: boolean }>;
   onSelectRepo: (repoPath: string) => void;
   onAddProject: (repoPath: string) => Promise<void>;
   onRemoveProject: (repoPath: string) => void;
@@ -206,21 +206,23 @@ export default function ProjectList({
   }, [repos, groups, gitStatuses]);
 
   const groupActivity = useMemo(() => {
-    const result: Record<string, { hasAttention: boolean; hasCrash: boolean; hasActivity: boolean }> = {};
+    const result: Record<string, { hasAttention: boolean; hasCrash: boolean; hasActivity: boolean; hasActive: boolean }> = {};
     for (const group of sortedGroups) {
       const groupRepos = groupedRepos.get(group.id) ?? [];
       let hasAttention = false;
       let hasCrash = false;
       let hasActivity = false;
+      let hasActive = false;
       for (const repo of groupRepos) {
         const a = projectActivity[repo.path];
         if (a) {
           if (a.terminalCount > 0 || a.runningCount > 0) hasActivity = true;
           if (a.hasAttention) hasAttention = true;
           if (a.hasCrash) hasCrash = true;
+          if (a.hasActive) hasActive = true;
         }
       }
-      result[group.id] = { hasAttention, hasCrash, hasActivity };
+      result[group.id] = { hasAttention, hasCrash, hasActivity, hasActive };
     }
     return result;
   }, [sortedGroups, groupedRepos, projectActivity]);

--- a/src/components/sidebar/ProjectList.tsx
+++ b/src/components/sidebar/ProjectList.tsx
@@ -14,6 +14,7 @@ import AssistantList from "./AssistantList";
 import TerminalList from "./TerminalList";
 import CommandsRow from "./CommandsRow";
 import GitStatusRow from "./GitStatusRow";
+import TodoRow from "./TodoRow";
 
 interface ProjectListProps {
   repos: RepoInfo[];
@@ -285,6 +286,7 @@ export default function ProjectList({
 
             <CommandsRow badge={commandsBadge} />
             <GitStatusRow repoPath={repo.path} />
+            <TodoRow repoPath={repo.path} />
           </div>
         )}
       </div>

--- a/src/components/sidebar/ProjectList.tsx
+++ b/src/components/sidebar/ProjectList.tsx
@@ -290,7 +290,7 @@ export default function ProjectList({
   };
 
   return (
-    <div className="flex flex-col gap-0.5 px-2 pb-2">
+    <div className="flex flex-col gap-0.5 pb-2">
       {sortedGroups.map((group) => {
         const groupRepos = groupedRepos.get(group.id) ?? [];
         const isGroupExpanded = expandedGroups.has(group.id);

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -10,8 +10,6 @@ import SidebarUsage from "./SidebarUsage";
 import AgentSessionList, { type AgentSessionItem } from "./AgentSessionList";
 import SidebarSectionToggle from "./SidebarSectionToggle";
 
-const PROJECTS_COLLAPSED_STORAGE_KEY = "shep:sidebar-projects-collapsed";
-
 interface SidebarProps {
   repos: RepoInfo[];
   groups: RepoGroup[];
@@ -51,9 +49,8 @@ export default function Sidebar({
   onDeleteGroup,
   onMoveToGroup,
 }: SidebarProps) {
-  const [projectsCollapsed, setProjectsCollapsed] = useState(
-    () => window.localStorage.getItem(PROJECTS_COLLAPSED_STORAGE_KEY) === "true",
-  );
+  // Projects always starts expanded on launch; collapsing is per-session only.
+  const [projectsCollapsed, setProjectsCollapsed] = useState(false);
   const projectState = useTerminalStore((s) => s.projectState);
   const projectCommands = useCommandStore((s) => s.projectCommands);
   const tabActivity = useTerminalStore((s) => s.tabActivity);
@@ -152,10 +149,6 @@ export default function Sidebar({
   useEffect(() => {
     if (!projectSettingsLoaded) void loadProjectSettings();
   }, [projectSettingsLoaded, loadProjectSettings]);
-
-  useEffect(() => {
-    window.localStorage.setItem(PROJECTS_COLLAPSED_STORAGE_KEY, String(projectsCollapsed));
-  }, [projectsCollapsed]);
 
   return (
     <div className="w-72 shrink-0 flex flex-col h-full pr-4 mr-4 border-r border-[var(--glass-border)]" onContextMenu={(e) => e.preventDefault()}>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Folder } from "lucide-react";
 import type { RepoInfo, RepoGroup, CommandState } from "../../lib/types";
 import { useTerminalStore } from "../../stores/useTerminalStore";
 import { useCommandStore } from "../../stores/useCommandStore";
@@ -172,7 +171,6 @@ export default function Sidebar({
         <div className="sidebar-section px-2 pb-2">
           <SidebarSectionToggle
             label="Projects"
-            icon={<Folder size={14} />}
             collapsed={projectsCollapsed}
             badge={repos.length}
             onToggle={handleToggleProjects}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import type { RepoInfo, RepoGroup, CommandState } from "../../lib/types";
 import { useTerminalStore } from "../../stores/useTerminalStore";
 import { useCommandStore } from "../../stores/useCommandStore";
 import { useGitStore } from "../../stores/useGitStore";
+import { useProjectSettingsStore } from "../../stores/useProjectSettingsStore";
 import ProjectList from "./ProjectList";
 import SidebarFooter from "./SidebarFooter";
 import SidebarUsage from "./SidebarUsage";
@@ -58,15 +59,18 @@ export default function Sidebar({
   const projectCommands = useCommandStore((s) => s.projectCommands);
   const tabActivity = useTerminalStore((s) => s.tabActivity);
   const gitStatuses = useGitStore((s) => s.projectGitStatus);
+  const projectSettings = useProjectSettingsStore((s) => s.settings);
+  const projectSettingsLoaded = useProjectSettingsStore((s) => s.hasLoaded);
+  const loadProjectSettings = useProjectSettingsStore((s) => s.loadSettings);
 
-  // Only subscribe to the fields that affect the sidebar badges (bell, crash).
+  // Only subscribe to the fields that affect the sidebar activity indicators.
   // Returns a stable string so the selector doesn't trigger re-renders when
-  // unrelated tabActivity fields change (e.g. active toggling during streaming).
+  // unrelated tabActivity fields change.
   const activityKey = useTerminalStore((s) => {
     const parts: string[] = [];
     for (const [ptyId, a] of Object.entries(s.tabActivity)) {
-      if (a.bell || (!a.alive && a.exitCode !== 0)) {
-        parts.push(`${ptyId}:${a.bell ? "b" : ""}${!a.alive ? `x${a.exitCode}` : ""}`);
+      if (a.active || a.bell || !a.alive) {
+        parts.push(`${ptyId}:${a.active ? "a" : ""}${a.bell ? "b" : ""}${!a.alive ? `x${a.exitCode}` : ""}`);
       }
     }
     return parts.join(",");
@@ -74,26 +78,31 @@ export default function Sidebar({
 
   const projectActivity = useMemo(() => {
     const tabActivity = useTerminalStore.getState().tabActivity;
-    const activity: Record<string, { terminalCount: number; runningCount: number; hasAttention: boolean; hasCrash: boolean }> = {};
+    const activity: Record<string, { terminalCount: number; runningCount: number; hasAttention: boolean; hasCrash: boolean; hasActive: boolean }> = {};
     for (const repo of repos) {
       const ps = projectState[repo.path];
       const repoTabs = ps?.tabs ?? [];
       const cmds = projectCommands[repo.path] ?? [];
       let hasAttention = false;
       let hasCrash = false;
+      let hasActive = false;
+      let liveTerminalCount = 0;
       for (const tab of repoTabs) {
         if (tab.kind !== "terminal" && tab.kind !== "assistant") continue;
         const a = tabActivity[tab.ptyId];
         if (a) {
           if (a.bell) hasAttention = true;
+          if (a.active) hasActive = true;
           if (!a.alive && a.exitCode !== 0) hasCrash = true;
         }
+        if (!a || a.alive) liveTerminalCount += 1;
       }
       activity[repo.path] = {
-        terminalCount: repoTabs.filter((t) => t.kind === "terminal" || t.kind === "assistant").length,
+        terminalCount: liveTerminalCount,
         runningCount: cmds.filter((c) => c.status === "running").length,
         hasAttention,
         hasCrash,
+        hasActive,
       };
     }
     return activity;
@@ -142,18 +151,24 @@ export default function Sidebar({
   }, []);
 
   useEffect(() => {
+    if (!projectSettingsLoaded) void loadProjectSettings();
+  }, [projectSettingsLoaded, loadProjectSettings]);
+
+  useEffect(() => {
     window.localStorage.setItem(PROJECTS_COLLAPSED_STORAGE_KEY, String(projectsCollapsed));
   }, [projectsCollapsed]);
 
   return (
     <div className="w-72 shrink-0 flex flex-col h-full pr-4 mr-4 border-r border-[var(--glass-border)]" onContextMenu={(e) => e.preventDefault()}>
       <div className="flex-1 overflow-y-auto min-h-0">
-        <AgentSessionList
-          sessions={agentSessions}
-          activeRepoPath={activeRepoPath}
-          activeTabId={activeTabId}
-          onSelectSession={onSelectProjectTab}
-        />
+        {projectSettings.showAgentSessionsInSidebar && (
+          <AgentSessionList
+            sessions={agentSessions}
+            activeRepoPath={activeRepoPath}
+            activeTabId={activeTabId}
+            onSelectSession={onSelectProjectTab}
+          />
+        )}
         <div className="sidebar-section px-2 pb-2">
           <SidebarSectionToggle
             label="Projects"

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,11 +1,16 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Folder } from "lucide-react";
 import type { RepoInfo, RepoGroup, CommandState } from "../../lib/types";
 import { useTerminalStore } from "../../stores/useTerminalStore";
 import { useCommandStore } from "../../stores/useCommandStore";
-import SectionHeader from "./SectionHeader";
+import { useGitStore } from "../../stores/useGitStore";
 import ProjectList from "./ProjectList";
 import SidebarFooter from "./SidebarFooter";
 import SidebarUsage from "./SidebarUsage";
+import AgentSessionList, { type AgentSessionItem } from "./AgentSessionList";
+import SidebarSectionToggle from "./SidebarSectionToggle";
+
+const PROJECTS_COLLAPSED_STORAGE_KEY = "shep:sidebar-projects-collapsed";
 
 interface SidebarProps {
   repos: RepoInfo[];
@@ -19,6 +24,7 @@ interface SidebarProps {
   onNewAssistant: () => void;
   onOpenInEditor: (repoPath: string) => void;
   onSelectTab: (tabId: string) => void;
+  onSelectProjectTab: (repoPath: string, tabId: string) => void;
   onCloseTab: (tabId: string) => void;
   onNewShell: () => void;
   onRenameGroup: (groupId: string, newName: string) => void;
@@ -38,14 +44,20 @@ export default function Sidebar({
   onNewAssistant,
   onOpenInEditor,
   onSelectTab,
+  onSelectProjectTab,
   onCloseTab,
   onNewShell,
   onRenameGroup,
   onDeleteGroup,
   onMoveToGroup,
 }: SidebarProps) {
+  const [projectsCollapsed, setProjectsCollapsed] = useState(
+    () => window.localStorage.getItem(PROJECTS_COLLAPSED_STORAGE_KEY) === "true",
+  );
   const projectState = useTerminalStore((s) => s.projectState);
   const projectCommands = useCommandStore((s) => s.projectCommands);
+  const tabActivity = useTerminalStore((s) => s.tabActivity);
+  const gitStatuses = useGitStore((s) => s.projectGitStatus);
 
   // Only subscribe to the fields that affect the sidebar badges (bell, crash).
   // Returns a stable string so the selector doesn't trigger re-renders when
@@ -87,29 +99,91 @@ export default function Sidebar({
     return activity;
   }, [repos, projectState, projectCommands, activityKey]);
 
+  const agentSessions = useMemo<AgentSessionItem[]>(() => {
+    const repoNames = new Map(repos.map((repo) => [repo.path, repo.name]));
+
+    const sessions: AgentSessionItem[] = [];
+    for (const [repoPath, state] of Object.entries(projectState)) {
+      const projectName = repoNames.get(repoPath) ?? repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+      const branchName = gitStatuses[repoPath]?.branch?.trim() || null;
+      for (const tab of state.tabs) {
+        if (tab.kind !== "assistant") continue;
+        const activity = tabActivity[tab.ptyId];
+        if (activity && !activity.alive && activity.exitCode === 0) continue;
+        sessions.push({ tab, projectName, branchName });
+      }
+    }
+
+    return sessions.sort((a, b) => {
+      const aIsActive = a.tab.repoPath === activeRepoPath && a.tab.id === activeTabId;
+      const bIsActive = b.tab.repoPath === activeRepoPath && b.tab.id === activeTabId;
+      if (aIsActive !== bIsActive) return aIsActive ? -1 : 1;
+
+      const aActivity = tabActivity[a.tab.ptyId];
+      const bActivity = tabActivity[b.tab.ptyId];
+      const aNeedsAttention = Boolean(aActivity?.bell || (aActivity && !aActivity.alive && aActivity.exitCode !== 0));
+      const bNeedsAttention = Boolean(bActivity?.bell || (bActivity && !bActivity.alive && bActivity.exitCode !== 0));
+      if (aNeedsAttention !== bNeedsAttention) return aNeedsAttention ? -1 : 1;
+
+      const aIsStreaming = Boolean(aActivity?.active);
+      const bIsStreaming = Boolean(bActivity?.active);
+      if (aIsStreaming !== bIsStreaming) return aIsStreaming ? -1 : 1;
+
+      const aAlive = aActivity?.alive ?? true;
+      const bAlive = bActivity?.alive ?? true;
+      if (aAlive !== bAlive) return aAlive ? -1 : 1;
+
+      return a.projectName.localeCompare(b.projectName) || a.tab.label.localeCompare(b.tab.label);
+    });
+  }, [repos, projectState, tabActivity, gitStatuses, activeRepoPath, activeTabId]);
+
+  const handleToggleProjects = useCallback(() => {
+    setProjectsCollapsed((value) => !value);
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(PROJECTS_COLLAPSED_STORAGE_KEY, String(projectsCollapsed));
+  }, [projectsCollapsed]);
+
   return (
     <div className="w-72 shrink-0 flex flex-col h-full pr-4 mr-4 border-r border-[var(--glass-border)]" onContextMenu={(e) => e.preventDefault()}>
       <div className="flex-1 overflow-y-auto min-h-0">
-        <SectionHeader label="Projects" />
-        <ProjectList
-          repos={repos}
-          groups={groups}
+        <AgentSessionList
+          sessions={agentSessions}
           activeRepoPath={activeRepoPath}
           activeTabId={activeTabId}
-          commands={commands}
-          projectActivity={projectActivity}
-          onSelectRepo={onSelectRepo}
-          onAddProject={onAddProject}
-          onRemoveProject={onRemoveProject}
-          onNewAssistant={onNewAssistant}
-          onOpenInEditor={onOpenInEditor}
-          onSelectTab={onSelectTab}
-          onCloseTab={onCloseTab}
-          onNewShell={onNewShell}
-          onRenameGroup={onRenameGroup}
-          onDeleteGroup={onDeleteGroup}
-          onMoveToGroup={onMoveToGroup}
+          onSelectSession={onSelectProjectTab}
         />
+        <div className="sidebar-section px-2 pb-2">
+          <SidebarSectionToggle
+            label="Projects"
+            icon={<Folder size={14} />}
+            collapsed={projectsCollapsed}
+            badge={repos.length}
+            onToggle={handleToggleProjects}
+          />
+          {!projectsCollapsed && (
+            <ProjectList
+              repos={repos}
+              groups={groups}
+              activeRepoPath={activeRepoPath}
+              activeTabId={activeTabId}
+              commands={commands}
+              projectActivity={projectActivity}
+              onSelectRepo={onSelectRepo}
+              onAddProject={onAddProject}
+              onRemoveProject={onRemoveProject}
+              onNewAssistant={onNewAssistant}
+              onOpenInEditor={onOpenInEditor}
+              onSelectTab={onSelectTab}
+              onCloseTab={onCloseTab}
+              onNewShell={onNewShell}
+              onRenameGroup={onRenameGroup}
+              onDeleteGroup={onDeleteGroup}
+              onMoveToGroup={onMoveToGroup}
+            />
+          )}
+        </div>
       </div>
       <SidebarUsage />
       <SidebarFooter />

--- a/src/components/sidebar/SidebarSectionToggle.tsx
+++ b/src/components/sidebar/SidebarSectionToggle.tsx
@@ -1,9 +1,7 @@
-import type { ReactNode } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
 interface SidebarSectionToggleProps {
   label: string;
-  icon: ReactNode;
   collapsed: boolean;
   badge?: number | string | null;
   onToggle: () => void;
@@ -11,7 +9,6 @@ interface SidebarSectionToggleProps {
 
 export default function SidebarSectionToggle({
   label,
-  icon,
   collapsed,
   badge,
   onToggle,
@@ -23,14 +20,11 @@ export default function SidebarSectionToggle({
       title={collapsed ? `Show ${label.toLowerCase()}` : `Hide ${label.toLowerCase()}`}
       aria-expanded={!collapsed}
     >
-      <span className="shrink-0 w-[14px] flex items-center justify-center">
-        {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
-      </span>
-      <span className="shrink-0 w-[14px] flex items-center justify-center" style={{ color: "var(--section-icon-color)" }}>
-        {icon}
-      </span>
       <span className="sidebar-section-toggle__label truncate">{label}</span>
       {badge != null && <span className="badge">{badge}</span>}
+      <span className="sidebar-section-toggle__chevron shrink-0">
+        {collapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
+      </span>
     </button>
   );
 }

--- a/src/components/sidebar/SidebarSectionToggle.tsx
+++ b/src/components/sidebar/SidebarSectionToggle.tsx
@@ -29,7 +29,7 @@ export default function SidebarSectionToggle({
       <span className="shrink-0 w-[14px] flex items-center justify-center" style={{ color: "var(--section-icon-color)" }}>
         {icon}
       </span>
-      <span className="truncate">{label}</span>
+      <span className="sidebar-section-toggle__label truncate">{label}</span>
       {badge != null && <span className="badge">{badge}</span>}
     </button>
   );

--- a/src/components/sidebar/SidebarSectionToggle.tsx
+++ b/src/components/sidebar/SidebarSectionToggle.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+interface SidebarSectionToggleProps {
+  label: string;
+  icon: ReactNode;
+  collapsed: boolean;
+  badge?: number | string | null;
+  onToggle: () => void;
+}
+
+export default function SidebarSectionToggle({
+  label,
+  icon,
+  collapsed,
+  badge,
+  onToggle,
+}: SidebarSectionToggleProps) {
+  return (
+    <button
+      className="section-toggle sidebar-section-toggle"
+      onClick={onToggle}
+      title={collapsed ? `Show ${label.toLowerCase()}` : `Hide ${label.toLowerCase()}`}
+      aria-expanded={!collapsed}
+    >
+      <span className="shrink-0 w-[14px] flex items-center justify-center">
+        {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+      </span>
+      <span className="shrink-0 w-[14px] flex items-center justify-center" style={{ color: "var(--section-icon-color)" }}>
+        {icon}
+      </span>
+      <span className="truncate">{label}</span>
+      {badge != null && <span className="badge">{badge}</span>}
+    </button>
+  );
+}

--- a/src/components/sidebar/SidebarUsage.tsx
+++ b/src/components/sidebar/SidebarUsage.tsx
@@ -39,7 +39,7 @@ interface SidebarUtilizationItem {
   provider: UsageProvider;
   label: string;
   pct: number;
-  tokens: number;
+  tokens: number | null;
   sublabel: string;
   pace: { status: PaceStatus; elapsedPct: number } | null;
   meta?: string;
@@ -54,6 +54,11 @@ function sidebarProviderWindows(provider: UsageProvider, snap: ProviderUsageSnap
   const windows = snap.summaryWindows
     .filter((sw) => sw.usedPercent != null && sw.sourceType === "provider")
     .filter((sw) => sw.window === window || sw.window.startsWith("24h_"));
+
+  if (provider === "antigravity") {
+    const mostUsed = [...windows].sort((a, b) => (b.usedPercent ?? 0) - (a.usedPercent ?? 0))[0];
+    return mostUsed ? [mostUsed] : windows;
+  }
 
   if (provider !== "gemini") return windows;
 
@@ -106,7 +111,7 @@ function buildUtilizationItems(
     const config = settings[provider];
     const snap = snapshots[provider];
     if (!config.show || !snap) return;
-    const tokens = windowTokenTotal(snap, window);
+    const tokens = provider === "antigravity" ? null : windowTokenTotal(snap, window);
 
     sidebarProviderWindows(provider, snap, window)
       .forEach((w) => {
@@ -156,7 +161,7 @@ function buildUtilizationItems(
     }
   });
 
-  return items.sort((a, b) => b.tokens - a.tokens || b.pct - a.pct);
+  return items.sort((a, b) => (b.tokens ?? 0) - (a.tokens ?? 0) || b.pct - a.pct);
 }
 
 function UsageTooltip({ tip }: { tip: TooltipState }) {
@@ -187,10 +192,12 @@ function UsageTooltip({ tip }: { tip: TooltipState }) {
           <span>Used</span>
           <span>{formatPercent(item.pct)}</span>
         </div>
-        <div className="sidebar-usage__tooltip-row">
-          <span>Tokens</span>
-          <span>{formatTokenCount(item.tokens)}</span>
-        </div>
+        {item.tokens != null && (
+          <div className="sidebar-usage__tooltip-row">
+            <span>Tokens</span>
+            <span>{formatTokenCount(item.tokens)}</span>
+          </div>
+        )}
         {item.sublabel && (
           <div className="sidebar-usage__tooltip-row">
             <span>Detail</span>

--- a/src/components/sidebar/TerminalItem.tsx
+++ b/src/components/sidebar/TerminalItem.tsx
@@ -6,19 +6,13 @@ import { useTerminalStore } from "../../stores/useTerminalStore";
 import { handleActionKey } from "../../lib/a11y";
 import ContextMenu from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
+import ActivityIndicator, { getTabActivityStatus } from "./ActivityIndicator";
 
 interface TerminalItemProps {
   tab: TerminalTabData;
   isActive: boolean;
   onClick: () => void;
   onClose: () => void;
-}
-
-function dotClass(activity: TabActivity | undefined): string {
-  if (!activity) return "sidebar-status-dot--idle";
-  if (!activity.alive) return activity.exitCode === 0 ? "sidebar-status-dot--idle" : "sidebar-status-dot--exited";
-  if (activity.active) return "sidebar-status-dot--active";
-  return "sidebar-status-dot--idle";
 }
 
 export default function TerminalItem({
@@ -58,7 +52,7 @@ export default function TerminalItem({
       >
         <span className="shrink-0">{tabKindMeta.terminal.icon(14)}</span>
         <span className="min-w-0 truncate text-left">{tab.label}</span>
-        <span className={`sidebar-status-dot ${dotClass(activity)}`} />
+        <ActivityIndicator status={getTabActivityStatus(activity)} activity={activity} />
       </div>
       {menu && (
         <ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />

--- a/src/components/sidebar/TodoRow.tsx
+++ b/src/components/sidebar/TodoRow.tsx
@@ -1,5 +1,6 @@
 import { useTodoStore } from "../../stores/useTodoStore";
 import { useTerminalStore } from "../../stores/useTerminalStore";
+import { useProjectSettingsStore } from "../../stores/useProjectSettingsStore";
 import { panelTabId } from "../../lib/types";
 import tabKindMeta from "../../lib/tabKindMeta";
 
@@ -8,12 +9,15 @@ interface TodoRowProps {
 }
 
 export default function TodoRow({ repoPath }: TodoRowProps) {
+  const showTodos = useProjectSettingsStore((s) => s.settings.showTodos);
   const files = useTodoStore((s) => s.projectTodos[repoPath]);
   const isActive = useTerminalStore((s) => {
     const path = s.activeProjectPath;
     if (!path) return false;
     return s.projectState[path]?.activeTabId === panelTabId("todos");
   });
+
+  if (!showTodos) return null;
 
   const openCount =
     files?.reduce(

--- a/src/components/sidebar/TodoRow.tsx
+++ b/src/components/sidebar/TodoRow.tsx
@@ -1,0 +1,36 @@
+import { useTodoStore } from "../../stores/useTodoStore";
+import { useTerminalStore } from "../../stores/useTerminalStore";
+import { panelTabId } from "../../lib/types";
+import tabKindMeta from "../../lib/tabKindMeta";
+
+interface TodoRowProps {
+  repoPath: string;
+}
+
+export default function TodoRow({ repoPath }: TodoRowProps) {
+  const files = useTodoStore((s) => s.projectTodos[repoPath]);
+  const isActive = useTerminalStore((s) => {
+    const path = s.activeProjectPath;
+    if (!path) return false;
+    return s.projectState[path]?.activeTabId === panelTabId("todos");
+  });
+
+  const openCount =
+    files?.reduce(
+      (sum, file) => sum + file.items.filter((item) => !item.checked).length,
+      0,
+    ) ?? 0;
+
+  return (
+    <button
+      onClick={() => useTerminalStore.getState().addPanelTab("todos")}
+      className={`section-toggle ${isActive ? "!text-[var(--text-primary)] !bg-white/6" : ""}`}
+    >
+      <span className="shrink-0" style={{ color: "var(--section-icon-color)" }}>
+        {tabKindMeta.todos.icon(14)}
+      </span>
+      <span className="truncate">To-dos</span>
+      {openCount > 0 && <span className="badge">{openCount}</span>}
+    </button>
+  );
+}

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -13,7 +13,11 @@ import {
   unregisterTerminal,
 } from "../../hooks/usePty";
 import { TERMINAL_LINE_HEIGHT, buildCSSFontFamily } from "../../lib/terminalConfig";
-import { preserveTerminalViewport } from "../../lib/terminalViewport";
+import {
+  preserveTerminalViewport,
+  resyncTerminalViewport,
+  terminalBottomOffset,
+} from "../../lib/terminalViewport";
 import { createTerminalTheme } from "./terminalTheme";
 import { useThemeStore } from "../../stores/useThemeStore";
 import { notifyAgent } from "../../lib/notifications";
@@ -190,6 +194,12 @@ export default function TerminalView({
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
       if (disposed) return;
 
+      // Snapshot the scroll position from xterm's internal buffer before
+      // touching anything: while the container was display:none the browser
+      // zeroed the DOM viewport's scrollTop, so the internal position is the
+      // only surviving record of where the user was.
+      const bottomOffset = terminalBottomOffset(term);
+
       // Re-apply the current theme now that the container is visible.
       // Theme changes that occurred while hidden were deferred to avoid
       // corrupting xterm's scroll state.
@@ -224,6 +234,11 @@ export default function TerminalView({
       await fitAndResize();
       if (disposed) return;
 
+      // fitAndResize skips the fit (and its viewport preservation) when the
+      // dimensions didn't change — the common case when returning to a tab —
+      // so the zeroed DOM scrollTop must be re-asserted unconditionally.
+      resyncTerminalViewport(term, bottomOffset);
+
       if (!attachedRef.current) {
         registerTerminal(ptyId, term);
         flushPendingOutput(ptyId);
@@ -233,6 +248,7 @@ export default function TerminalView({
       window.setTimeout(() => {
         if (disposed) return;
         void fitAndResize();
+        resyncTerminalViewport(term, bottomOffset);
         term.focus();
       }, 100);
 

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -13,6 +13,7 @@ import {
   unregisterTerminal,
 } from "../../hooks/usePty";
 import { TERMINAL_LINE_HEIGHT, buildCSSFontFamily } from "../../lib/terminalConfig";
+import { preserveTerminalViewport } from "../../lib/terminalViewport";
 import { createTerminalTheme } from "./terminalTheme";
 import { useThemeStore } from "../../stores/useThemeStore";
 import { notifyAgent } from "../../lib/notifications";
@@ -121,17 +122,25 @@ export default function TerminalView({
     const cached = terminalCache.get(ptyId);
     if (!cached) return;
 
-    cached.fitAddon.fit();
-    const size = { cols: cached.term.cols, rows: cached.term.rows };
+    const proposedSize = cached.fitAddon.proposeDimensions();
+    if (!proposedSize) return;
+
+    const size = { cols: proposedSize.cols, rows: proposedSize.rows };
     const lastSize = lastSizeRef.current;
 
     if (
       lastSize &&
       lastSize.cols === size.cols &&
-      lastSize.rows === size.rows
+      lastSize.rows === size.rows &&
+      cached.term.cols === size.cols &&
+      cached.term.rows === size.rows
     ) {
       return;
     }
+
+    preserveTerminalViewport(cached.term, () => {
+      cached.fitAddon.fit();
+    });
 
     lastSizeRef.current = size;
     await resizePty(ptyId, size.cols, size.rows).catch((error) => {

--- a/src/components/terminal/terminalTheme.ts
+++ b/src/components/terminal/terminalTheme.ts
@@ -5,6 +5,7 @@ import type { TerminalSettings } from "../../lib/types";
 import { resizePty } from "../../lib/tauri";
 import { terminalCache } from "./TerminalView";
 import { buildCSSFontFamily } from "../../lib/terminalConfig";
+import { preserveTerminalViewport } from "../../lib/terminalViewport";
 
 // Utility to make hex colors partially transparent
 function withAlpha(hex: string, alpha: number): string {
@@ -83,7 +84,9 @@ export function applyTerminalSettings(settings: TerminalSettings): void {
     // and cached from scratch. Without this, xterm keeps rendering glyphs
     // with the *old* font's metrics, causing clipping and misalignment.
     entry.rendererAddon?.clearTextureAtlas?.();
-    entry.fitAddon.fit();
+    preserveTerminalViewport(entry.term, () => {
+      entry.fitAddon.fit();
+    });
     entry.term.refresh(0, entry.term.rows - 1);
     resizePty(ptyId, entry.term.cols, entry.term.rows).catch((error) => {
       if (import.meta.env.DEV) {

--- a/src/components/todos/TodosPanel.tsx
+++ b/src/components/todos/TodosPanel.tsx
@@ -1,0 +1,173 @@
+import { useState, Fragment } from "react";
+import { Square, SquareCheckBig } from "lucide-react";
+import tabKindMeta from "../../lib/tabKindMeta";
+import type { TodoFile, TodoItem } from "../../lib/types";
+import { useTerminalStore } from "../../stores/useTerminalStore";
+import { useTodoStore } from "../../stores/useTodoStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+import { getErrorMessage } from "../../lib/errors";
+
+interface TodoFileSectionProps {
+  file: TodoFile;
+  showFileLabel: boolean;
+  onToggle: (file: TodoFile, item: TodoItem) => void;
+}
+
+function TodoFileSection({ file, showFileLabel, onToggle }: TodoFileSectionProps) {
+  let previousSection: string | null | undefined;
+
+  return (
+    <div className="todos-panel__file">
+      {showFileLabel && <div className="todos-panel__file-label">{file.relativePath}</div>}
+      {file.items.map((item) => {
+        const sectionChanged = item.section !== previousSection;
+        previousSection = item.section;
+        return (
+          <Fragment key={`${item.line}-${item.text}`}>
+            {sectionChanged && item.section && (
+              <div className="todos-panel__section">{item.section}</div>
+            )}
+            <button
+              className={`todos-panel__item ${item.checked ? "todos-panel__item--done" : ""}`}
+              style={item.indent > 0 ? { paddingLeft: 10 + item.indent * 8 } : undefined}
+              onClick={() => onToggle(file, item)}
+            >
+              <span className="todos-panel__item-box">
+                {item.checked ? <SquareCheckBig size={15} /> : <Square size={15} />}
+              </span>
+              <span className="todos-panel__item-text">{item.text}</span>
+            </button>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function TodosPanel() {
+  const activeProjectPath = useTerminalStore((s) => s.activeProjectPath);
+  const files = useTodoStore((s) =>
+    activeProjectPath ? s.projectTodos[activeProjectPath] : undefined,
+  );
+  const pushNotice = useNoticeStore((s) => s.pushNotice);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  if (!activeProjectPath) {
+    return (
+      <div className="commands-panel commands-panel--empty">
+        Select a project to see its to-dos
+      </div>
+    );
+  }
+
+  const todoFiles = files ?? [];
+  const allItems = todoFiles.flatMap((f) => f.items);
+  const openCount = allItems.filter((i) => !i.checked).length;
+  const doneCount = allItems.length - openCount;
+  const hasFile = todoFiles.length > 0;
+
+  const handleToggle = (file: TodoFile, item: TodoItem) => {
+    useTodoStore
+      .getState()
+      .toggleItem(activeProjectPath, file.path, item.line, item.text, !item.checked)
+      .catch((error) => {
+        pushNotice({
+          tone: "error",
+          title: "Couldn't update to-do",
+          message: getErrorMessage(error),
+        });
+      });
+  };
+
+  const handleAdd = async () => {
+    const text = draft.trim();
+    if (!text || saving) return;
+    setSaving(true);
+    try {
+      // New items go to the primary (first-discovered) file; with no file
+      // yet, the backend creates TODO.md at the project root.
+      await useTodoStore
+        .getState()
+        .addItem(activeProjectPath, todoFiles[0]?.path ?? null, text);
+      setDraft("");
+    } catch (error) {
+      pushNotice({
+        tone: "error",
+        title: "Couldn't add to-do",
+        message: getErrorMessage(error),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="commands-panel">
+      <div className="commands-panel__header">
+        <div className="commands-panel__title-wrap">
+          <span className="shrink-0">{tabKindMeta.todos.icon(15)}</span>
+          <div className="commands-panel__title-block">
+            <div className="commands-panel__title">To-dos</div>
+            <div className="commands-panel__subtitle">
+              {hasFile
+                ? `${openCount} open · ${doneCount} done · ${todoFiles
+                    .map((f) => f.relativePath)
+                    .join(", ")}`
+                : "No TODO.md in this project"}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="todos-panel__list">
+        {!hasFile && (
+          <div className="todos-panel__empty">
+            Add a to-do below and Shep will create a <code>TODO.md</code> at the
+            project root. It&apos;s a plain markdown checklist — you and your coding
+            agents share the same file, and edits from either side show up here.
+          </div>
+        )}
+        {todoFiles.map((file) => (
+          <TodoFileSection
+            key={file.path}
+            file={file}
+            showFileLabel={todoFiles.length > 1}
+            onToggle={handleToggle}
+          />
+        ))}
+        {hasFile && allItems.length === 0 && (
+          <div className="todos-panel__empty">This list is empty — add a to-do below.</div>
+        )}
+      </div>
+
+      <form
+        className="todos-panel__add"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleAdd();
+        }}
+      >
+        <input
+          className="todos-panel__add-input"
+          type="text"
+          placeholder={hasFile ? "Add a to-do" : "Add a to-do (creates TODO.md)"}
+          value={draft}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          disabled={saving}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="glass-button todos-panel__add-btn"
+          disabled={!draft.trim() || saving}
+        >
+          {saving ? "Adding..." : "Add"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/usage/usageHelpers.ts
+++ b/src/components/usage/usageHelpers.ts
@@ -1,7 +1,7 @@
 import type { ProviderUsageSnapshot, UsageProvider, UsageWindowSnapshot } from "../../lib/types";
 
 const WINDOW_PRIORITY = ["5h", "7d", "30d"];
-export const ALL_USAGE_PROVIDERS: UsageProvider[] = ["claude", "codex", "gemini", "opencode", "pi"];
+export const ALL_USAGE_PROVIDERS: UsageProvider[] = ["claude", "codex", "antigravity", "gemini", "opencode", "pi"];
 export const TONE_COLORS: Record<string, string> = {
   low: "color-mix(in srgb, var(--status-added) var(--color-opacity-utilization), transparent)",
   medium: "color-mix(in srgb, var(--status-attention) var(--color-opacity-utilization), transparent)",
@@ -35,6 +35,8 @@ export function getProviderLabel(provider: UsageProvider): string {
       return "Claude";
     case "gemini":
       return "Gemini";
+    case "antigravity":
+      return "Antigravity";
     case "opencode":
       return "opencode";
     case "pi":

--- a/src/hooks/useGitWatcher.ts
+++ b/src/hooks/useGitWatcher.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { watchRepo, unwatchRepo } from "../lib/tauri";
 import { useGitStore } from "../stores/useGitStore";
+import { useTodoStore } from "../stores/useTodoStore";
 
 interface FsChangedPayload {
   paths: string[];
@@ -17,6 +18,7 @@ export function useGitWatcher(repoPaths: string[]) {
   useEffect(() => {
     const unlisten = listen<FsChangedPayload>("git-fs-changed", (event) => {
       void useGitStore.getState().refreshAll(event.payload.paths);
+      void useTodoStore.getState().refreshAll(event.payload.paths);
     });
 
     return () => {
@@ -49,6 +51,7 @@ export function useGitWatcher(repoPaths: string[]) {
 
     // Initial refresh
     void refreshAll(repoPaths);
+    void useTodoStore.getState().refreshAll(repoPaths);
   }, [repoPaths.join("\0")]);
 
   useEffect(() => {

--- a/src/hooks/useGitWatcher.ts
+++ b/src/hooks/useGitWatcher.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { watchRepo, unwatchRepo } from "../lib/tauri";
 import { useGitStore } from "../stores/useGitStore";
 import { useTodoStore } from "../stores/useTodoStore";
+import { useProjectSettingsStore } from "../stores/useProjectSettingsStore";
 
 interface FsChangedPayload {
   paths: string[];
@@ -18,7 +19,9 @@ export function useGitWatcher(repoPaths: string[]) {
   useEffect(() => {
     const unlisten = listen<FsChangedPayload>("git-fs-changed", (event) => {
       void useGitStore.getState().refreshAll(event.payload.paths);
-      void useTodoStore.getState().refreshAll(event.payload.paths);
+      if (useProjectSettingsStore.getState().settings.showTodos) {
+        void useTodoStore.getState().refreshAll(event.payload.paths);
+      }
     });
 
     return () => {
@@ -51,7 +54,9 @@ export function useGitWatcher(repoPaths: string[]) {
 
     // Initial refresh
     void refreshAll(repoPaths);
-    void useTodoStore.getState().refreshAll(repoPaths);
+    if (useProjectSettingsStore.getState().settings.showTodos) {
+      void useTodoStore.getState().refreshAll(repoPaths);
+    }
   }, [repoPaths.join("\0")]);
 
   useEffect(() => {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -33,7 +33,7 @@ async function ensureNotificationPermission() {
 }
 
 export async function notifyAgent(ptyId: number, message: string) {
-  useTerminalStore.getState().setTabBell(ptyId);
+  useTerminalStore.getState().setTabBell(ptyId, message);
 
   if (focused) {
     return;

--- a/src/lib/tabKindMeta.tsx
+++ b/src/lib/tabKindMeta.tsx
@@ -1,4 +1,4 @@
-import { FolderTree, Terminal, SquareTerminal, List, ExternalLink } from "lucide-react";
+import { FolderTree, Terminal, SquareTerminal, List, ListTodo, ExternalLink } from "lucide-react";
 import type { TabKind } from "./types";
 
 export interface TabKindMeta {
@@ -31,6 +31,10 @@ const meta: Record<TabKind, TabKindMeta> = {
   launcher: {
     label: "New Agent",
     icon: (size) => <SquareTerminal size={size} />,
+  },
+  todos: {
+    label: "To-dos",
+    icon: (size) => <ListTodo size={size} />,
   },
 };
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -26,6 +26,7 @@ import type {
   PiConfig,
   PiSettings,
   DiffFileStat,
+  TodoFile,
 } from "./types";
 
 // ── Workspace commands ──────────────────────────────────────────────
@@ -211,6 +212,29 @@ export function gitCurrentBranch(path: string): Promise<string> {
 
 export function gitListBranches(path: string): Promise<string[]> {
   return invoke("git_list_branches", { path });
+}
+
+// ── Todo commands ───────────────────────────────────────────────────
+
+export function readTodos(repoPath: string): Promise<TodoFile[]> {
+  return invoke("read_todos", { repoPath });
+}
+
+export function toggleTodo(
+  filePath: string,
+  line: number,
+  expectedText: string,
+  checked: boolean,
+): Promise<void> {
+  return invoke("toggle_todo", { filePath, line, expectedText, checked });
+}
+
+export function addTodo(
+  repoPath: string,
+  filePath: string | null,
+  text: string,
+): Promise<void> {
+  return invoke("add_todo", { repoPath, filePath, text });
 }
 
 export function gitListWorktrees(path: string): Promise<WorktreeEntry[]> {

--- a/src/lib/terminalViewport.ts
+++ b/src/lib/terminalViewport.ts
@@ -1,8 +1,14 @@
 import type { Terminal } from "@xterm/xterm";
 
+/** Distance of the viewport from the bottom of the scrollback, in lines.
+ *  0 means pinned to the bottom (following output). */
+export function terminalBottomOffset(term: Terminal): number {
+  const buffer = term.buffer.active;
+  return Math.max(0, buffer.baseY - buffer.viewportY);
+}
+
 export function preserveTerminalViewport(term: Terminal, update: () => void) {
-  const before = term.buffer.active;
-  const bottomOffset = Math.max(0, before.baseY - before.viewportY);
+  const bottomOffset = terminalBottomOffset(term);
 
   update();
 
@@ -13,4 +19,24 @@ export function preserveTerminalViewport(term: Terminal, update: () => void) {
 
   const after = term.buffer.active;
   term.scrollToLine(Math.max(0, after.baseY - bottomOffset));
+}
+
+/** Re-assert a scroll position onto the DOM viewport after the terminal's
+ *  container was `display:none`. Browsers zero a hidden element's scrollTop
+ *  and never restore it, while xterm's internal position survives — and
+ *  xterm ignores scroll requests that already match its internal position,
+ *  so a plain scrollToLine would no-op and leave the DOM stuck at the top.
+ *  Jumping elsewhere first forces a real scroll; both calls land within one
+ *  render frame, so the intermediate position is never painted. */
+export function resyncTerminalViewport(term: Terminal, bottomOffset: number): void {
+  const buffer = term.buffer.active;
+  if (buffer.baseY === 0) return;
+
+  const target = Math.max(0, buffer.baseY - bottomOffset);
+  term.scrollToLine(target === 0 ? buffer.baseY : 0);
+  if (bottomOffset === 0) {
+    term.scrollToBottom();
+  } else {
+    term.scrollToLine(target);
+  }
 }

--- a/src/lib/terminalViewport.ts
+++ b/src/lib/terminalViewport.ts
@@ -1,0 +1,16 @@
+import type { Terminal } from "@xterm/xterm";
+
+export function preserveTerminalViewport(term: Terminal, update: () => void) {
+  const before = term.buffer.active;
+  const bottomOffset = Math.max(0, before.baseY - before.viewportY);
+
+  update();
+
+  if (bottomOffset === 0) {
+    term.scrollToBottom();
+    return;
+  }
+
+  const after = term.buffer.active;
+  term.scrollToLine(Math.max(0, after.baseY - bottomOffset));
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,7 @@ export interface EditorSettings {
 
 export interface ProjectSettings {
   autoImportWorktrees: boolean;
+  showAgentSessionsInSidebar: boolean;
 }
 
 export interface KeybindingSettings {
@@ -134,6 +135,9 @@ export interface TabActivity {
   active: boolean;
   exitCode: number | null;
   bell: boolean;
+  lastOutputAt: number | null;
+  lastAttentionAt: number | null;
+  lastNotificationMessage: string | null;
 }
 
 // ── Coding assistants ───────────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -238,7 +238,7 @@ export interface PtyColorTheme {
 
 // ── Usage ──────────────────────────────────────────────────────────
 
-export type UsageProvider = "codex" | "claude" | "gemini" | "opencode" | "pi";
+export type UsageProvider = "codex" | "claude" | "antigravity" | "gemini" | "opencode" | "pi";
 
 export type BudgetMode = "subscription" | "custom";
 
@@ -251,6 +251,7 @@ export interface ProviderBudgetConfig {
 export interface UsageSettings {
   claude: ProviderBudgetConfig;
   codex: ProviderBudgetConfig;
+  antigravity: ProviderBudgetConfig;
   gemini: ProviderBudgetConfig;
   opencode: ProviderBudgetConfig;
   pi: ProviderBudgetConfig;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -93,7 +93,7 @@ export type SessionMode = "standard" | "yolo";
 
 // ── Unified tab model ──────────────────────────────────────────────
 
-export type PanelTabKind = "git" | "commands" | "launcher";
+export type PanelTabKind = "git" | "commands" | "launcher" | "todos";
 export type TabKind = "terminal" | "assistant" | PanelTabKind;
 
 interface TabBase {
@@ -125,6 +125,7 @@ export const panelTabDefaults: Record<PanelTabKind, { label: string }> = {
   git: { label: "Files" },
   commands: { label: "Commands" },
   launcher: { label: "New Agent" },
+  todos: { label: "To-dos" },
 };
 
 
@@ -179,6 +180,25 @@ export interface WorktreeEntry {
 export interface CreatedWorktree {
   path: string;
   branch: string;
+}
+
+// ── Todos (TODO.md files) ────────────────────────────────────────────
+
+export interface TodoItem {
+  /** 0-based line index in the file; used for surgical edits. */
+  line: number;
+  text: string;
+  checked: boolean;
+  /** Leading whitespace width, for rendering nested items. */
+  indent: number;
+  /** Nearest preceding markdown heading, if any. */
+  section: string | null;
+}
+
+export interface TodoFile {
+  path: string;
+  relativePath: string;
+  items: TodoItem[];
 }
 
 // ── Git diff stats ───────────────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface EditorSettings {
 export interface ProjectSettings {
   autoImportWorktrees: boolean;
   showAgentSessionsInSidebar: boolean;
+  showTodos: boolean;
 }
 
 export interface KeybindingSettings {

--- a/src/stores/useProjectSettingsStore.ts
+++ b/src/stores/useProjectSettingsStore.ts
@@ -4,6 +4,7 @@ import { getProjectSettings, saveProjectSettings } from "../lib/tauri";
 
 const DEFAULT_SETTINGS: ProjectSettings = {
   autoImportWorktrees: true,
+  showAgentSessionsInSidebar: true,
 };
 
 interface ProjectSettingsStore {

--- a/src/stores/useProjectSettingsStore.ts
+++ b/src/stores/useProjectSettingsStore.ts
@@ -5,6 +5,7 @@ import { getProjectSettings, saveProjectSettings } from "../lib/tauri";
 const DEFAULT_SETTINGS: ProjectSettings = {
   autoImportWorktrees: true,
   showAgentSessionsInSidebar: true,
+  showTodos: true,
 };
 
 interface ProjectSettingsStore {

--- a/src/stores/useTerminalStore.ts
+++ b/src/stores/useTerminalStore.ts
@@ -27,7 +27,7 @@ interface TerminalStore {
   initActivity: (ptyId: number) => void;
   setTabActive: (ptyId: number, active: boolean) => void;
   setTabExited: (ptyId: number, exitCode: number) => void;
-  setTabBell: (ptyId: number) => void;
+  setTabBell: (ptyId: number, message?: string) => void;
   clearTabBell: (ptyId: number) => void;
   removeActivity: (ptyId: number) => void;
   getAllProjectTabs: (repoPath: string) => UnifiedTab[];
@@ -260,7 +260,15 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     set((state) => ({
       tabActivity: {
         ...state.tabActivity,
-        [ptyId]: { alive: true, active: true, exitCode: null, bell: false },
+        [ptyId]: {
+          alive: true,
+          active: true,
+          exitCode: null,
+          bell: false,
+          lastOutputAt: Date.now(),
+          lastAttentionAt: null,
+          lastNotificationMessage: null,
+        },
       },
     }));
   },
@@ -269,7 +277,16 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     set((state) => {
       const prev = state.tabActivity[ptyId];
       if (!prev || prev.active === active) return state;
-      return { tabActivity: { ...state.tabActivity, [ptyId]: { ...prev, active } } };
+      return {
+        tabActivity: {
+          ...state.tabActivity,
+          [ptyId]: {
+            ...prev,
+            active,
+            lastOutputAt: active ? Date.now() : prev.lastOutputAt,
+          },
+        },
+      };
     });
   },
 
@@ -281,11 +298,21 @@ export const useTerminalStore = create<TerminalStore>((set, get) => ({
     });
   },
 
-  setTabBell: (ptyId: number) => {
+  setTabBell: (ptyId: number, message?: string) => {
     set((state) => {
       const prev = state.tabActivity[ptyId];
       if (!prev) return state;
-      return { tabActivity: { ...state.tabActivity, [ptyId]: { ...prev, bell: true } } };
+      return {
+        tabActivity: {
+          ...state.tabActivity,
+          [ptyId]: {
+            ...prev,
+            bell: true,
+            lastAttentionAt: Date.now(),
+            lastNotificationMessage: message?.trim() || prev.lastNotificationMessage,
+          },
+        },
+      };
     });
   },
 

--- a/src/stores/useTodoStore.ts
+++ b/src/stores/useTodoStore.ts
@@ -1,0 +1,92 @@
+import { create } from "zustand";
+import type { TodoFile } from "../lib/types";
+import { readTodos, toggleTodo, addTodo } from "../lib/tauri";
+
+interface TodoStore {
+  /** TODO.md files per repo. The file on disk is the source of truth — this
+   *  is only a render cache, refreshed from fs events and after every write. */
+  projectTodos: Record<string, TodoFile[]>;
+  refreshTodos: (repoPath: string) => Promise<void>;
+  refreshAll: (repoPaths: string[]) => Promise<void>;
+  toggleItem: (
+    repoPath: string,
+    filePath: string,
+    line: number,
+    expectedText: string,
+    checked: boolean,
+  ) => Promise<void>;
+  addItem: (repoPath: string, filePath: string | null, text: string) => Promise<void>;
+  removeProject: (repoPath: string) => void;
+}
+
+function todoFilesEqual(a: TodoFile[] | undefined, b: TodoFile[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].path !== b[i].path || a[i].items.length !== b[i].items.length) return false;
+    for (let j = 0; j < a[i].items.length; j++) {
+      const x = a[i].items[j];
+      const y = b[i].items[j];
+      if (x.line !== y.line || x.text !== y.text || x.checked !== y.checked) return false;
+    }
+  }
+  return true;
+}
+
+export const useTodoStore = create<TodoStore>((set, get) => ({
+  projectTodos: {},
+
+  refreshTodos: async (repoPath: string) => {
+    try {
+      const files = await readTodos(repoPath);
+      set((state) => {
+        if (todoFilesEqual(state.projectTodos[repoPath], files)) return state;
+        return { projectTodos: { ...state.projectTodos, [repoPath]: files } };
+      });
+    } catch {
+      // Repo may have been removed from disk — leave the cache untouched
+    }
+  },
+
+  refreshAll: async (repoPaths: string[]) => {
+    const results = await Promise.allSettled(repoPaths.map((p) => readTodos(p)));
+
+    set((state) => {
+      const prev = state.projectTodos;
+      let changed = false;
+      const next = { ...prev };
+
+      for (let i = 0; i < repoPaths.length; i++) {
+        const result = results[i];
+        if (result.status !== "fulfilled") continue;
+        if (!todoFilesEqual(prev[repoPaths[i]], result.value)) {
+          next[repoPaths[i]] = result.value;
+          changed = true;
+        }
+      }
+
+      return changed ? { projectTodos: next } : state;
+    });
+  },
+
+  toggleItem: async (repoPath, filePath, line, expectedText, checked) => {
+    try {
+      await toggleTodo(filePath, line, expectedText, checked);
+    } finally {
+      // Reload even on failure — a mismatch error means the file changed
+      // under us and the UI should catch up.
+      await get().refreshTodos(repoPath);
+    }
+  },
+
+  addItem: async (repoPath, filePath, text) => {
+    await addTodo(repoPath, filePath, text);
+    await get().refreshTodos(repoPath);
+  },
+
+  removeProject: (repoPath: string) => {
+    set((state) => {
+      const { [repoPath]: _, ...rest } = state.projectTodos;
+      return { projectTodos: rest };
+    });
+  },
+}));

--- a/src/stores/useUsageSettingsStore.ts
+++ b/src/stores/useUsageSettingsStore.ts
@@ -5,6 +5,7 @@ import type { UsageSettings, UsageProvider, ProviderBudgetConfig } from "../lib/
 const DEFAULT_SETTINGS: UsageSettings = {
   claude: { show: true, budgetMode: "subscription", monthlyBudget: null },
   codex: { show: true, budgetMode: "subscription", monthlyBudget: null },
+  antigravity: { show: true, budgetMode: "subscription", monthlyBudget: null },
   gemini: { show: false, budgetMode: "subscription", monthlyBudget: null },
   opencode: { show: true, budgetMode: "custom", monthlyBudget: 100 },
   pi: { show: false, budgetMode: "custom", monthlyBudget: null },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1112,7 +1112,6 @@ select {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding-left: 18px;
 }
 
 .sidebar-section__overflow {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1071,9 +1071,41 @@ select {
   padding-top: 6px;
 }
 
+/* Hairline divider between adjacent top-level sections (e.g. Agent
+   Sessions → Projects). Only applies when both are rendered. */
+.sidebar-section + .sidebar-section {
+  margin-top: 6px;
+  border-top: 1px solid var(--glass-border);
+  padding-top: 10px;
+}
+
+/* Top-level section headers are typographic labels, distinct from the
+   icon-led item rows nested beneath them. */
+.sidebar-section-toggle {
+  min-height: 24px;
+  padding: 3px 8px;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
 .sidebar-section-toggle__label {
   min-width: 0;
   flex: 1;
+  text-align: left;
+}
+
+.sidebar-section-toggle__chevron {
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.45;
+  transition: opacity 120ms ease;
+}
+
+.sidebar-section-toggle:hover .sidebar-section-toggle__chevron {
+  opacity: 0.9;
 }
 
 .sidebar-section__list {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -389,6 +389,79 @@ select {
   background: var(--status-attention);
 }
 
+.activity-indicator {
+  position: relative;
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  margin-left: auto;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--overlay) 25%, transparent);
+}
+
+.activity-indicator--idle {
+  background: color-mix(in srgb, var(--overlay) 22%, transparent);
+}
+
+.activity-indicator--running {
+  background: color-mix(in srgb, var(--status-running) 62%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--status-running) 16%, transparent);
+}
+
+.activity-indicator--active {
+  background: var(--status-added);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--status-added) 38%, transparent);
+  animation: activity-indicator-pulse 1.25s ease-in-out infinite;
+}
+
+.activity-indicator--active::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border: 1px solid color-mix(in srgb, var(--status-added) 48%, transparent);
+  border-radius: 50%;
+  animation: activity-indicator-ring 1.25s ease-out infinite;
+}
+
+.activity-indicator--attention {
+  background: var(--status-attention);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--status-attention) 18%, transparent);
+}
+
+.activity-indicator--failed {
+  background: var(--status-crashed);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--status-crashed) 16%, transparent);
+}
+
+@keyframes activity-indicator-pulse {
+  0%, 100% {
+    opacity: 0.72;
+    transform: scale(0.9);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+@keyframes activity-indicator-ring {
+  0% {
+    opacity: 0.8;
+    transform: scale(0.7);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.35);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-indicator--active,
+  .activity-indicator--active::after {
+    animation: none;
+  }
+}
+
 /* Option card (form pickers, selectable cards) */
 .option-card {
   display: flex;
@@ -998,6 +1071,11 @@ select {
   padding-top: 6px;
 }
 
+.sidebar-section-toggle__label {
+  min-width: 0;
+  flex: 1;
+}
+
 .sidebar-section__list {
   display: flex;
   flex-direction: column;
@@ -1046,7 +1124,7 @@ select {
   white-space: nowrap;
 }
 
-.agent-session-row__dot {
+.agent-session-row__indicator {
   margin-left: 2px;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -994,6 +994,62 @@ select {
   outline-offset: 2px;
 }
 
+.sidebar-section {
+  padding-top: 6px;
+}
+
+.sidebar-section__list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: 18px;
+}
+
+.sidebar-section__overflow {
+  padding: 3px 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.65;
+}
+
+.agent-session-row {
+  align-items: center;
+  gap: 7px;
+  min-height: 38px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.agent-session-row__text {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  line-height: 1.2;
+}
+
+.agent-session-row__branch {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-session-row__project {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: var(--text-body);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-session-row__dot {
+  margin-left: 2px;
+}
+
 /* Sidebar footer buttons (Settings, Usage, Ports) — visually distinct from tabs */
 .sidebar-footer-btn {
   display: flex;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3386,3 +3386,128 @@ select {
   white-space: nowrap;
   font-family: monospace;
 }
+
+/* ── Todos panel ───────────────────────────────────────────────────── */
+
+.todos-panel__list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px 0;
+}
+
+.todos-panel__file + .todos-panel__file {
+  margin-top: 16px;
+}
+
+.todos-panel__file-label {
+  padding: 2px 10px 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: monospace;
+}
+
+.todos-panel__section {
+  padding: 12px 10px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.todos-panel__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 6px 10px;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--text-body);
+  line-height: 1.45;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.todos-panel__item:hover {
+  background: color-mix(in srgb, var(--overlay) 4%, transparent);
+  color: var(--text-primary);
+}
+
+.todos-panel__item-box {
+  flex-shrink: 0;
+  display: inline-flex;
+  margin-top: 2px;
+  color: var(--text-muted);
+}
+
+.todos-panel__item--done {
+  color: var(--text-muted);
+}
+
+.todos-panel__item--done .todos-panel__item-text {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.todos-panel__item--done .todos-panel__item-box {
+  color: var(--accent, var(--text-secondary));
+}
+
+.todos-panel__empty {
+  padding: 8px 10px;
+  color: var(--text-muted);
+  font-size: var(--text-body);
+  line-height: 1.5;
+  max-width: 480px;
+}
+
+.todos-panel__empty code {
+  font-family: monospace;
+  color: var(--text-secondary);
+}
+
+.todos-panel__add {
+  display: flex;
+  gap: 8px;
+  padding: 12px 0 14px;
+  border-top: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.todos-panel__add-input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--overlay) 3%, transparent);
+  color: var(--text-primary);
+  font-size: var(--text-body);
+  outline: none;
+}
+
+.todos-panel__add-input:focus {
+  border-color: var(--border-hover);
+}
+
+.todos-panel__add-input::placeholder {
+  color: var(--text-muted);
+}
+
+.todos-panel__add-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-hover);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.todos-panel__add-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary

Rolls up four stacked branches since v0.2.8:

### Agent sessions & usage (`design/sidebar-agent-sessions`)
- Global Agent Sessions section in the sidebar with activity indicators
- Antigravity usage tracking
- Preserve terminal viewport during window resizes

### Project to-dos (`feature/todo-md`)
- Any `TODO.md`/`TODOS.md` in a repo surfaces as a To-dos panel + sidebar row with open-count badge
- The markdown file is the source of truth: GFM checkboxes (sections, nesting) parsed and edited with surgical line writes, so coding agents and the user share the same list
- File created lazily at the repo root on first to-do; never auto-inserted
- Live sync via the existing fs watcher; agent edits show up within the debounce window
- Settings toggle (Settings → Projects → Project To-dos), default on

### Sidebar polish (`design/sidebar-section-polish`)
- Top-level section headers are now typographic labels (small caps, chevron on the right) instead of chevron+icon rows
- Hairline divider between Agent Sessions and Projects
- Agent session rows align flush with project items
- Both top-level sections always start expanded on launch (collapse is session-only)

### Terminal scroll restore (`fix/terminal-scroll-restore`)
- Fixes losing scroll position when returning to a tab: hidden terminals (`display:none`) get their DOM scrollTop zeroed by the browser, and the dimensions-unchanged early return skipped every resync. Snapshot the position from xterm's internal buffer on re-show and unconditionally re-assert it.

## Testing
- 5 Rust unit tests for the todos module (parse, surgical toggle, stale-text rejection, lazy create, discovery/ignore rules)
- `tsc`, `vite build`, `cargo check`, clippy all clean
- Sidebar and to-dos verified visually in the dev app

🤖 Generated with [Claude Code](https://claude.com/claude-code)