### PR TITLE
Add Windows support with 1:1 feature parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,28 @@ Shep gives each repo a dedicated workspace for terminals, AI coding agents, comm
 - **Status indicators** so crashed or noisy sessions are easy to spot
 - **Usage tracking** for AI coding assistant costs across providers
 - **In-app notices** for common failures instead of silent errors or browser alerts
-- **Native macOS packaging** via Tauri
+- **Native macOS and Windows packaging** via Tauri
 
 ## Download
 
-Download the latest `.dmg` from [GitHub Releases](https://github.com/stumptowndoug/shep/releases).
+Download the latest release from [GitHub Releases](https://github.com/stumptowndoug/shep/releases).
 
-After downloading:
+**macOS** — download the `.dmg`:
 
 1. Open the `.dmg`
 2. Drag `Shep.app` into `Applications`
 3. Launch Shep
 
-Note: the current release flow is aimed at small-group testing. If the app is unsigned or not notarized, macOS may show an extra security prompt on first launch.
+**Windows** — download and run `shep_X.Y.Z_x64-setup.exe`.
+
+Note: the current release flow is aimed at small-group testing. If the app is unsigned or not notarized, macOS may show an extra security prompt on first launch, and Windows SmartScreen may warn before running the installer.
 
 ## Requirements
 
 For using Shep:
 
-- macOS
+- macOS or Windows 10/11 (WebView2 Runtime is preinstalled on Windows 10/11; the installer fetches it if missing)
+- git on PATH (on Windows: [Git for Windows](https://gitforwindows.org/))
 - A local git repo to work from
 - Any CLI agents you want to launch already installed on your machine
 
@@ -52,7 +55,8 @@ For building from source:
 - Node.js 20+
 - `pnpm`
 - Rust via `rustup`
-- Xcode Command Line Tools
+- macOS: Xcode Command Line Tools
+- Windows: Visual Studio Build Tools 2022 with the "Desktop development with C++" workload (MSVC toolchain)
 
 ## Getting Started
 
@@ -146,15 +150,18 @@ pnpm build
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
 
-Build artifacts land here:
+Build artifacts land here (release builds; debug builds land under `target/debug/bundle/`):
+
+macOS:
 
 - App bundle: `src-tauri/target/release/bundle/macos/shep.app`
 - DMG: `src-tauri/target/release/bundle/dmg/`
 
-Debug artifacts land here:
+Windows:
 
-- App bundle: `src-tauri/target/debug/bundle/macos/shep.app`
-- DMG: `src-tauri/target/debug/bundle/dmg/`
+- Executable: `src-tauri/target/release/shep.exe`
+- NSIS installer: `src-tauri/target/release/bundle/nsis/shep_X.Y.Z_x64-setup.exe`
+- MSI: `src-tauri/target/release/bundle/msi/`
 
 ## Project Structure
 
@@ -186,19 +193,35 @@ src-tauri/src/workspace/
 For tester reports, include:
 
 - Shep version
-- macOS version
+- OS and version (macOS or Windows)
 - whether the issue happened in dev mode or the packaged app
 - the repo/workflow you were using
 - anything visible in the terminal or notice UI
 
+## Keyboard Shortcuts
+
+On macOS, shortcuts use the native menu accelerators (⌘T, ⇧⌘T, ⌘G, …). On Windows, app shortcuts use Ctrl+Shift chords so plain Ctrl+letter keystrokes still reach the terminal:
+
+| Action | macOS | Windows |
+| --- | --- | --- |
+| New Terminal | ⌘T | Ctrl+Shift+T |
+| New Agent Session | ⇧⌘T | Ctrl+Shift+A |
+| New Commands Panel | ⇧⌘C | Ctrl+Shift+M |
+| New Git Panel | ⌘G | Ctrl+Shift+G |
+| Open in Editor | ⌘E | Ctrl+Shift+E |
+| Toggle Sidebar | ⌘B | Ctrl+Shift+B |
+| Settings | ⌘, | Ctrl+, |
+| Copy / Paste in terminal | ⌘C / ⌘V | Ctrl+Shift+C / Ctrl+Shift+V |
+
 ## Releases
 
-Releases are built locally on macOS and published as a `.dmg` via GitHub Releases:
+Releases are built locally and published via GitHub Releases. See [docs/RELEASING.md](docs/RELEASING.md) for the full two-platform flow:
 
 1. `./scripts/bump-version.sh X.Y.Z` — updates `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml`, then commits the bump
-2. `./scripts/release-build.sh` — builds, signs, notarizes, and generates `latest.json`
-3. Smoke test the DMG, then `git tag vX.Y.Z && git push origin main vX.Y.Z`
-4. `gh release create` with the artifacts and release notes
+2. macOS lane: `./scripts/release-build.sh` — builds, signs, notarizes, and generates `latest.json`
+3. Windows lane: `pwsh scripts/release-build.ps1` — builds the NSIS installer and merges its entry into `latest.json`
+4. Smoke test the artifacts, then `git tag vX.Y.Z && git push origin main vX.Y.Z`
+5. `gh release create` with the artifacts from both lanes and the merged `latest.json`
 
 ## License
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,96 @@
+# Releasing Shep
+
+Shep ships for macOS (`.dmg`) and Windows (NSIS `setup.exe`). Both platforms
+share one updater endpoint — `releases/latest/download/latest.json` — so a
+release must carry a single `latest.json` containing an entry for every
+platform being shipped.
+
+## Prerequisites (both lanes)
+
+- Node.js 20+, `pnpm`, Rust via `rustup`
+- A `.env` file at the repo root (never committed) with at minimum:
+
+```bash
+# Updater artifact signing (same minisign key on every platform)
+TAURI_SIGNING_PRIVATE_KEY_PATH=/absolute/path/to/shep-updater.key
+# Only if the key is password protected:
+TAURI_SIGNING_PRIVATE_KEY_PASSWORD=...
+```
+
+The updater public key lives in `src-tauri/tauri.conf.json` under
+`plugins.updater.pubkey`; the same private key signs macOS and Windows
+artifacts.
+
+## macOS lane
+
+Additional `.env` variables:
+
+```bash
+APPLE_SIGNING_IDENTITY="Developer ID Application: ... (TEAMID)"
+APPLE_ID=you@example.com
+APPLE_PASSWORD=app-specific-password
+APPLE_TEAM_ID=TEAMID
+```
+
+The Developer ID certificate must be installed in the login Keychain
+(`DeveloperIDG2CA.cer` at the repo root is Apple's intermediate CA, needed to
+complete the trust chain when installing the signing cert).
+
+Run:
+
+```bash
+./scripts/release-build.sh
+```
+
+Produces: `.dmg`, `shep.app.tar.gz(.sig)`, and `latest.json` with a
+`darwin-aarch64` entry.
+
+## Windows lane
+
+Run on a Windows machine with the MSVC toolchain (Visual Studio Build Tools
+2022, "Desktop development with C++"):
+
+```powershell
+pwsh scripts/release-build.ps1
+```
+
+Produces: `shep_X.Y.Z_x64-setup.exe(.sig)` under
+`src-tauri/target/release/bundle/nsis/` and `latest.json` with a
+`windows-x86_64` entry.
+
+Authenticode signing is optional but recommended (unsigned installers trigger
+SmartScreen). Configure `bundle.windows.certificateThumbprint` or a
+`signCommand` (e.g. Azure Trusted Signing) in `tauri.conf.json` /
+`tauri.windows.conf.json` when a certificate is available.
+
+## Merging the lanes into one release
+
+Both `generate-update-json.sh` and `release-build.ps1` merge with an existing
+same-version `latest.json` instead of overwriting it. To ship both platforms:
+
+1. Run the macOS lane; keep its `latest.json`.
+2. Copy that `latest.json` to the repo root on the Windows machine and run the
+   Windows lane (or vice versa). The script adds its platform entry alongside
+   the existing one.
+3. Verify: `jq '.platforms | keys' latest.json` →
+   `["darwin-aarch64", "windows-x86_64"]`.
+
+Then publish once:
+
+```bash
+git tag vX.Y.Z && git push origin main vX.Y.Z
+gh release create vX.Y.Z \
+  <dmg> <shep.app.tar.gz> <shep.app.tar.gz.sig> \
+  <shep_X.Y.Z_x64-setup.exe> <shep_X.Y.Z_x64-setup.exe.sig> \
+  latest.json
+```
+
+Shipping a release with only one platform's entry in `latest.json` silently
+disables auto-update on the other platform — always merge before uploading.
+
+## Version bumps
+
+`./scripts/bump-version.sh X.Y.Z` updates `package.json`,
+`src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` and commits the bump.
+On Windows, run it from Git Bash with `jq` installed
+(`winget install jqlang.jq`).

--- a/scripts/generate-icon.mjs
+++ b/scripts/generate-icon.mjs
@@ -1,11 +1,13 @@
 import sharp from "sharp";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 const SIZE = 1024;
 const PADDING = 180; // breathing room around the logo
 const CORNER_RADIUS = 220;
 const LOGO_PATH = new URL("../assets/shep_logo.svg", import.meta.url);
-const OUTPUT_PATH = new URL("../assets/icon-1024.png", import.meta.url).pathname;
+// fileURLToPath (not URL.pathname) so the path is valid on Windows too
+const OUTPUT_PATH = fileURLToPath(new URL("../assets/icon-1024.png", import.meta.url));
 
 function extractViewBox(svg) {
   const match = svg.match(/viewBox="([^"]+)"/i);

--- a/scripts/generate-update-json.sh
+++ b/scripts/generate-update-json.sh
@@ -3,38 +3,49 @@
 # Generates latest.json for the Tauri updater plugin.
 # Run after `pnpm tauri build` with TAURI_SIGNING_PRIVATE_KEY set.
 #
+# Emits a platform entry for every signed update artifact found locally
+# (macOS app.tar.gz, Windows NSIS setup.exe) and merges with an existing
+# same-version latest.json, so the mac and Windows release lanes can run on
+# separate machines without clobbering each other's entries.
+#
 # Usage: bash scripts/generate-update-json.sh
 #
 set -euo pipefail
 
 VERSION=$(jq -r .version src-tauri/tauri.conf.json)
+PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RELEASE_BASE="https://github.com/stumptowndoug/shep/releases/download/v${VERSION}"
 
-# Locate the signed update artifact
-BUNDLE_DIR="src-tauri/target/release/bundle/macos"
-SIG_FILE="${BUNDLE_DIR}/shep.app.tar.gz.sig"
+MAC_SIG="src-tauri/target/release/bundle/macos/shep.app.tar.gz.sig"
+WIN_SIG="src-tauri/target/release/bundle/nsis/shep_${VERSION}_x64-setup.exe.sig"
 
-if [ ! -f "$SIG_FILE" ]; then
-  echo "Error: Signature file not found at ${SIG_FILE}"
+PLATFORMS="{}"
+
+if [ -f "$MAC_SIG" ]; then
+  PLATFORMS=$(jq --arg sig "$(cat "$MAC_SIG")" --arg url "${RELEASE_BASE}/shep.app.tar.gz" \
+    '. + {"darwin-aarch64": {"signature": $sig, "url": $url}}' <<<"$PLATFORMS")
+fi
+
+if [ -f "$WIN_SIG" ]; then
+  PLATFORMS=$(jq --arg sig "$(cat "$WIN_SIG")" --arg url "${RELEASE_BASE}/shep_${VERSION}_x64-setup.exe" \
+    '. + {"windows-x86_64": {"signature": $sig, "url": $url}}' <<<"$PLATFORMS")
+fi
+
+if [ "$PLATFORMS" = "{}" ]; then
+  echo "Error: no signed update artifacts found."
+  echo "Expected ${MAC_SIG} and/or ${WIN_SIG}."
   echo "Make sure TAURI_SIGNING_PRIVATE_KEY is set before building."
   exit 1
 fi
 
-SIGNATURE=$(cat "$SIG_FILE")
-PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-DOWNLOAD_URL="https://github.com/stumptowndoug/shep/releases/download/v${VERSION}/shep.app.tar.gz"
+# Merge with an existing latest.json from the other platform's lane when it
+# targets the same version; entries generated in this run win.
+if [ -f latest.json ] && [ "$(jq -r .version latest.json)" = "$VERSION" ]; then
+  PLATFORMS=$(jq -s '.[0] + .[1]' <(jq .platforms latest.json) <(printf "%s" "$PLATFORMS"))
+fi
 
-cat > latest.json <<EOF
-{
-  "version": "${VERSION}",
-  "notes": "See release notes on GitHub",
-  "pub_date": "${PUB_DATE}",
-  "platforms": {
-    "darwin-aarch64": {
-      "signature": "${SIGNATURE}",
-      "url": "${DOWNLOAD_URL}"
-    }
-  }
-}
-EOF
+jq -n --arg version "$VERSION" --arg pub_date "$PUB_DATE" --argjson platforms "$PLATFORMS" \
+  '{version: $version, notes: "See release notes on GitHub", pub_date: $pub_date, platforms: $platforms}' \
+  > latest.json
 
-echo "Generated latest.json for v${VERSION}"
+echo "Generated latest.json for v${VERSION} ($(jq -r '.platforms | keys | join(", ")' latest.json))"

--- a/scripts/release-build.ps1
+++ b/scripts/release-build.ps1
@@ -1,0 +1,150 @@
+# One-shot Windows release build for Shep — the Windows counterpart of
+# release-build.sh.
+#
+# - Verifies .env is present and loads it
+# - Verifies the updater signing key file exists and exports its contents
+# - Verifies package.json / tauri.conf.json / Cargo.toml versions match
+# - Runs pnpm install, pnpm tauri build
+# - Generates/merges latest.json (windows-x86_64 entry)
+# - Prints a summary of the resulting artifacts
+#
+# Authenticode signing is optional: configure bundle.windows
+# (certificateThumbprint or signCommand) in tauri.conf.json when a
+# certificate is available. Unsigned installers work but trigger SmartScreen.
+#
+# Usage: pwsh scripts/release-build.ps1  (or powershell -File)
+
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+
+function Step($msg)  { Write-Host "`n-- $msg" }
+function Ok($msg)    { Write-Host "   OK: $msg" }
+function Fail($msg)  { Write-Error "ERROR: $msg"; exit 1 }
+
+# -- Step 1: load .env ------------------------------------------------
+
+Step "Loading .env"
+
+if (-not (Test-Path ".env")) {
+    Fail ".env not found at repo root. See docs/RELEASING.md for required variables."
+}
+
+foreach ($line in Get-Content ".env") {
+    if ($line -match '^\s*#' -or $line -match '^\s*$') { continue }
+    $name, $value = $line -split '=', 2
+    if ($null -ne $value) {
+        Set-Item -Path "env:$($name.Trim())" -Value $value.Trim()
+    }
+}
+Ok "loaded .env"
+
+# -- Step 2: updater signing key --------------------------------------
+
+Step "Loading updater signing key"
+
+if (-not $env:TAURI_SIGNING_PRIVATE_KEY_PATH) {
+    Fail "TAURI_SIGNING_PRIVATE_KEY_PATH is not set in .env"
+}
+if (-not (Test-Path $env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
+    Fail "Updater key file not found at: $env:TAURI_SIGNING_PRIVATE_KEY_PATH"
+}
+$env:TAURI_SIGNING_PRIVATE_KEY = Get-Content $env:TAURI_SIGNING_PRIVATE_KEY_PATH -Raw
+if (-not $env:TAURI_SIGNING_PRIVATE_KEY) {
+    Fail "Updater key file is empty"
+}
+Ok "updater key loaded from $env:TAURI_SIGNING_PRIVATE_KEY_PATH"
+
+# -- Step 3: verify tools ----------------------------------------------
+
+Step "Verifying build tools"
+
+foreach ($tool in @("pnpm", "cargo")) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        Fail "$tool is not on PATH"
+    }
+    Ok $tool
+}
+
+# -- Step 4: version consistency ---------------------------------------
+
+Step "Verifying version consistency"
+
+$pkgVersion = (Get-Content "package.json" -Raw | ConvertFrom-Json).version
+$tauriVersion = (Get-Content "src-tauri/tauri.conf.json" -Raw | ConvertFrom-Json).version
+$cargoVersion = (Select-String -Path "src-tauri/Cargo.toml" -Pattern '^version\s*=\s*"([^"]+)"')[0].Matches.Groups[1].Value
+
+if ($pkgVersion -ne $tauriVersion -or $pkgVersion -ne $cargoVersion) {
+    Fail "Version mismatch: package.json=$pkgVersion tauri.conf.json=$tauriVersion Cargo.toml=$cargoVersion"
+}
+$version = $pkgVersion
+Ok "all three files agree on v$version"
+
+# -- Step 5: warn on dirty working tree ---------------------------------
+
+Step "Checking working tree"
+
+if (git status --porcelain) {
+    Write-Host "   WARNING: working tree is dirty. Release artifacts will include uncommitted changes."
+} else {
+    Ok "working tree is clean"
+}
+
+# -- Step 6: install deps + build ---------------------------------------
+
+Step "pnpm install"
+pnpm install
+if ($LASTEXITCODE -ne 0) { Fail "pnpm install failed" }
+
+Step "pnpm tauri build"
+pnpm tauri build
+if ($LASTEXITCODE -ne 0) { Fail "pnpm tauri build failed" }
+
+# -- Step 7: latest.json ------------------------------------------------
+
+Step "Generating latest.json"
+
+$setupExe = "src-tauri/target/release/bundle/nsis/shep_${version}_x64-setup.exe"
+$setupSig = "$setupExe.sig"
+
+if (-not (Test-Path $setupSig)) {
+    Fail "Signature file not found at $setupSig — was TAURI_SIGNING_PRIVATE_KEY set during the build?"
+}
+
+$platforms = [ordered]@{}
+# Merge entries from an existing same-version latest.json (mac lane output).
+if ((Test-Path "latest.json")) {
+    $existing = Get-Content "latest.json" -Raw | ConvertFrom-Json
+    if ($existing.version -eq $version) {
+        foreach ($prop in $existing.platforms.PSObject.Properties) {
+            $platforms[$prop.Name] = $prop.Value
+        }
+    }
+}
+$platforms["windows-x86_64"] = [ordered]@{
+    signature = (Get-Content $setupSig -Raw).Trim()
+    url       = "https://github.com/stumptowndoug/shep/releases/download/v$version/shep_${version}_x64-setup.exe"
+}
+
+[ordered]@{
+    version   = $version
+    notes     = "See release notes on GitHub"
+    pub_date  = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    platforms = $platforms
+} | ConvertTo-Json -Depth 5 | Set-Content -Path "latest.json" -Encoding utf8
+
+Ok "latest.json includes: $($platforms.Keys -join ', ')"
+
+# -- Step 8: summary ------------------------------------------------------
+
+Write-Host ""
+Write-Host "-- Release build complete: v$version"
+Write-Host ""
+Write-Host "   Installer:  $setupExe"
+Write-Host "   Signature:  $setupSig"
+Write-Host "   Metadata:   latest.json"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "   1. Smoke test the installer"
+Write-Host "   2. Coordinate with the macOS lane so one release carries both platforms"
+Write-Host "   3. gh release upload v$version $setupExe $setupSig latest.json"
+Write-Host ""

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -660,6 +660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +998,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1137,6 +1158,29 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -2186,6 +2230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2342,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2465,6 +2524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2650,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3461,6 +3539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rusqlite"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,7 +4060,9 @@ dependencies = [
  "core-foundation",
  "core-text",
  "dirs",
+ "dunce",
  "fix-path-env",
+ "fontdb",
  "libc",
  "log",
  "notify",
@@ -3985,6 +4071,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -3993,6 +4080,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -4040,6 +4128,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -4208,6 +4305,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -5040,6 +5151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,6 +5613,18 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -5965,6 +6097,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,11 +29,21 @@ dirs = "6.0"
 tauri-plugin-dialog = "2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 tauri-plugin-notification = "2"
-libc = "0.2"
 rusqlite = { version = "0.33", features = ["bundled"] }
 notify = { version = "7", features = ["macos_fsevent"] }
-core-text = "21"
-core-foundation = "0.10"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 url = "2"
+dunce = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-text = "21"
+core-foundation = "0.10"
+
+[target.'cfg(windows)'.dependencies]
+fontdb = "0.23"
+sysinfo = "0.36"
+which = "7"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -169,15 +169,29 @@ pub fn reveal_in_finder(path: &str) -> Result<(), String> {
         return Err(format!("Path does not exist: {path}"));
     }
 
-    let status = Command::new("open")
-        .arg(path)
-        .status()
-        .map_err(|e| format!("Failed to open Finder: {e}"))?;
-
-    if status.success() {
+    #[cfg(windows)]
+    {
+        // explorer.exe routinely exits non-zero even on success, so a
+        // successful spawn counts as success.
+        crate::util::quiet_command("explorer")
+            .arg(path)
+            .spawn()
+            .map_err(|e| format!("Failed to open File Explorer: {e}"))?;
         Ok(())
-    } else {
-        Err(format!("Finder exited with status: {status}"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        let status = Command::new("open")
+            .arg(path)
+            .status()
+            .map_err(|e| format!("Failed to open Finder: {e}"))?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("Finder exited with status: {status}"))
+        }
     }
 }
 
@@ -193,6 +207,15 @@ pub fn open_url(url: &str, workspace: State<'_, WorkspaceManager>) -> Result<(),
         return Err(format!("URL scheme '{scheme}' is not allowed"));
     }
 
+    // rundll32 receives the URL as a plain argument, so no cmd.exe shell
+    // escaping issues with '&' or '^' in query strings.
+    #[cfg(windows)]
+    let status = crate::util::quiet_command("rundll32")
+        .args(["url.dll,FileProtocolHandler", url])
+        .status()
+        .map_err(|e| format!("Failed to open URL: {e}"))?;
+
+    #[cfg(not(windows))]
     let status = Command::new("open")
         .arg(url)
         .status()
@@ -313,6 +336,19 @@ pub fn shutdown_and_quit(app: tauri::AppHandle, pty_manager: State<'_, PtyManage
     app.exit(0);
 }
 
+/// Kill sessions and stop watchers without exiting. Used before installing an
+/// update on Windows, where the updater plugin launches the installer and
+/// terminates the process directly — bypassing the ExitRequested cleanup — so
+/// child processes must be reaped first or they orphan and hold files open.
+#[tauri::command]
+pub fn prepare_for_update(pty_manager: State<'_, PtyManager>, watcher: State<'_, GitWatcher>) {
+    if !pty_manager.begin_shutdown() {
+        return;
+    }
+    watcher.shutdown();
+    pty_manager.kill_all();
+}
+
 // ── File watcher commands ─────────────────────────────────────────
 
 #[tauri::command]
@@ -431,7 +467,9 @@ pub async fn git_diff_stats(path: String) -> Result<Vec<DiffFileStat>, String> {
 
 #[tauri::command]
 pub fn get_username() -> String {
-    std::env::var("USER").unwrap_or_default()
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_default()
 }
 
 #[tauri::command]
@@ -443,18 +481,42 @@ pub fn get_home_directory() -> Result<String, String> {
 
 #[tauri::command]
 pub fn get_default_shell() -> String {
-    std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+    #[cfg(windows)]
+    {
+        // Prefer PowerShell 7+, then Windows PowerShell, then cmd.exe. Bare
+        // names are returned (not full paths) — the PTY spawn wraps commands
+        // with `cmd /c`, which resolves them from PATH.
+        for shell in ["pwsh.exe", "powershell.exe"] {
+            if which::which(shell).is_ok() {
+                return shell.to_string();
+            }
+        }
+        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    }
+
+    #[cfg(not(windows))]
+    {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+    }
 }
 
 #[tauri::command]
 pub fn get_computer_name() -> String {
-    Command::new("scutil")
-        .args(["--get", "ComputerName"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_default()
+    #[cfg(windows)]
+    {
+        std::env::var("COMPUTERNAME").unwrap_or_default()
+    }
+
+    #[cfg(not(windows))]
+    {
+        Command::new("scutil")
+            .args(["--get", "ComputerName"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default()
+    }
 }
 
 // ── Todo commands ───────────────────────────────────────────────────
@@ -513,11 +575,21 @@ pub fn remove_skill(repo_path: &str, name: &str) -> Result<(), String> {
 
 #[tauri::command]
 pub fn check_command_exists(command: &str) -> bool {
-    Command::new("which")
-        .arg(command)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    // The `which` crate honors PATHEXT on Windows, so npm-installed .cmd/.ps1
+    // shims (claude.cmd, codex.cmd, ...) are found.
+    #[cfg(windows)]
+    {
+        which::which(command).is_ok()
+    }
+
+    #[cfg(not(windows))]
+    {
+        Command::new("which")
+            .arg(command)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
 }
 
 #[tauri::command]
@@ -593,12 +665,41 @@ pub async fn get_models_for_provider(
     }
 }
 
+/// Build the process invocation for a CLI tool. On Windows, npm-installed
+/// CLIs are .cmd/.bat shims that CreateProcess cannot exec directly — resolve
+/// them via PATHEXT and run through `cmd /c`.
+fn cli_command(cmd: &str) -> Option<Command> {
+    #[cfg(windows)]
+    {
+        let resolved = which::which(cmd).ok()?;
+        let ext = resolved
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase());
+        if matches!(ext.as_deref(), Some("cmd") | Some("bat")) {
+            let mut c = crate::util::quiet_command("cmd.exe");
+            c.arg("/c").arg(resolved);
+            Some(c)
+        } else {
+            Some(crate::util::quiet_command(resolved))
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        Some(Command::new(cmd))
+    }
+}
+
 fn query_cli_models(
     cmd: &str,
     args: &[&str],
     parser: fn(&str) -> Vec<String>,
 ) -> Vec<String> {
-    let mut child = match Command::new(cmd)
+    let Some(mut command) = cli_command(cmd) else {
+        return Vec::new();
+    };
+    let mut child = match command
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -707,6 +808,7 @@ pub struct MemoryStats {
     pub children_rss: u64,
 }
 
+#[cfg(not(windows))]
 #[tauri::command]
 pub async fn get_memory_stats(pty_manager: State<'_, PtyManager>) -> Result<MemoryStats, String> {
     let app_pid = std::process::id() as i32;
@@ -732,7 +834,36 @@ pub async fn get_memory_stats(pty_manager: State<'_, PtyManager>) -> Result<Memo
     Ok(MemoryStats { app_rss, children_rss })
 }
 
+#[cfg(windows)]
+#[tauri::command]
+pub async fn get_memory_stats(pty_manager: State<'_, PtyManager>) -> Result<MemoryStats, String> {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::All, true);
+
+    let app_rss = sys
+        .process(Pid::from_u32(std::process::id()))
+        .map(|p| p.memory())
+        .unwrap_or(0);
+
+    // The direct child + one level of descendants, matching the unix pgrep -P walk.
+    let mut children_rss: u64 = 0;
+    for pid in pty_manager.child_pids() {
+        let root = Pid::from_u32(pid);
+        children_rss += sys.process(root).map(|p| p.memory()).unwrap_or(0);
+        for process in sys.processes().values() {
+            if process.parent() == Some(root) {
+                children_rss += process.memory();
+            }
+        }
+    }
+
+    Ok(MemoryStats { app_rss, children_rss })
+}
+
 /// Get resident set size (RSS) for a single PID using `ps`.
+#[cfg(not(windows))]
 fn rss_for_pid(pid: i32) -> u64 {
     // ps -o rss= returns RSS in kilobytes
     Command::new("ps")
@@ -766,20 +897,47 @@ fn open_path_in_editor(repo_path: &str, editor_id: &str) -> Result<(), String> {
         }
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
+    {
+        let cli = editor_cli_name(editor_id)
+            .ok_or_else(|| format!("Unsupported editor: {editor_id}"))?;
+
+        let mut cmd = cli_command(cli).ok_or_else(|| {
+            format!("Could not find '{cli}' on PATH. Install the editor's command-line launcher.")
+        })?;
+
+        cmd.arg(repo_path)
+            .spawn()
+            .map_err(|e| format!("Failed to launch {cli}: {e}"))?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", windows)))]
     {
         let _ = repo_path;
         let _ = editor_id;
-        Err("Open in editor is currently only implemented for macOS.".to_string())
+        Err("Open in editor is currently only implemented for macOS and Windows.".to_string())
     }
 }
 
+#[cfg(target_os = "macos")]
 fn editor_app_name(editor_id: &str) -> Option<&'static str> {
     match editor_id {
         "vscode" => Some("Visual Studio Code"),
         "zed" => Some("Zed"),
         "cursor" => Some("Cursor"),
         "sublime_text" => Some("Sublime Text"),
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+fn editor_cli_name(editor_id: &str) -> Option<&'static str> {
+    match editor_id {
+        "vscode" => Some("code"),
+        "zed" => Some("zed"),
+        "cursor" => Some("cursor"),
+        "sublime_text" => Some("subl"),
         _ => None,
     }
 }
@@ -802,7 +960,7 @@ pub struct PortInfo {
 /// failure or timeout. Prevents hangs from stalling the app (e.g. NFS mounts,
 /// broken pipes). Matches port-whisperer's 5-10s timeout pattern.
 fn run_with_timeout(cmd: &str, args: &[&str], timeout: std::time::Duration) -> String {
-    let mut child = match Command::new(cmd).args(args)
+    let mut child = match crate::util::quiet_command(cmd).args(args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .spawn() {
@@ -834,6 +992,7 @@ fn run_with_timeout(cmd: &str, args: &[&str], timeout: std::time::Duration) -> S
         .unwrap_or_default()
 }
 
+#[cfg(not(windows))]
 #[tauri::command]
 pub async fn list_listening_ports(
     workspace: State<'_, WorkspaceManager>,
@@ -937,7 +1096,113 @@ pub async fn list_listening_ports(
     Ok(results)
 }
 
-/// Extract port number from lsof NAME field like "*:3000", "127.0.0.1:8080", "[::1]:5173"
+#[cfg(windows)]
+#[tauri::command]
+pub async fn list_listening_ports(
+    workspace: State<'_, WorkspaceManager>,
+) -> Result<Vec<PortInfo>, String> {
+    use sysinfo::{Pid, ProcessesToUpdate, System};
+
+    let repos = workspace.list_repos().unwrap_or_default();
+    let repo_paths: Vec<String> = repos.iter().map(|r| r.path.clone()).collect();
+    let timeout = std::time::Duration::from_secs(5);
+
+    // ── Step 1: netstat to find listening ports (TCP over v4 and v6) ──
+    let stdout = run_with_timeout("netstat", &["-ano"], timeout);
+
+    let mut port_map: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    struct Entry { port: u16, pid: u32 }
+    let mut entries: Vec<Entry> = Vec::new();
+
+    for line in stdout.lines() {
+        // "  TCP    0.0.0.0:3000    0.0.0.0:0    LISTENING    1234"
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 5 || parts[0] != "TCP" || parts[3] != "LISTENING" { continue; }
+
+        let port: u16 = match extract_port(parts[1]) {
+            Some(p) => p,
+            None => continue,
+        };
+        let pid: u32 = match parts[4].parse() { Ok(p) => p, Err(_) => continue };
+        if pid == 0 { continue; }
+
+        // Deduplicate by port (first entry wins, like port-whisperer)
+        if !port_map.insert(port) { continue; }
+
+        entries.push(Entry { port, pid });
+    }
+
+    if entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // ── Step 2: process metadata (name, RSS, uptime, cmdline, cwd) ────
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::All, true);
+
+    let mut results: Vec<PortInfo> = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        let Some(process) = sys.process(Pid::from_u32(entry.pid)) else { continue };
+
+        let name = process.name().to_string_lossy().to_string();
+        let process_name = if name.to_ascii_lowercase().ends_with(".exe") {
+            name[..name.len() - 4].to_string()
+        } else {
+            name
+        };
+
+        // Filter out system/desktop apps
+        if !is_dev_process(&process_name) { continue; }
+
+        let cmdline = process
+            .cmd()
+            .iter()
+            .map(|part| part.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let raw_cwd = process
+            .cwd()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let project_root = find_project_root(&raw_cwd);
+        let framework = detect_framework(&process_name, &cmdline, &project_root);
+        let project = match_project(&project_root, &repo_paths);
+
+        results.push(PortInfo {
+            port: entry.port,
+            pid: entry.pid,
+            process: process_name,
+            cwd: project_root,
+            project,
+            framework,
+            uptime: format_uptime(process.run_time()),
+            memory_kb: process.memory() / 1024,
+        });
+    }
+
+    results.sort_by_key(|p| p.port);
+    Ok(results)
+}
+
+/// Format seconds as ps-style etime: MM:SS, HH:MM:SS, or D-HH:MM:SS.
+#[cfg(windows)]
+fn format_uptime(total_secs: u64) -> String {
+    let days = total_secs / 86_400;
+    let hours = (total_secs % 86_400) / 3_600;
+    let minutes = (total_secs % 3_600) / 60;
+    let seconds = total_secs % 60;
+    if days > 0 {
+        format!("{days}-{hours:02}:{minutes:02}:{seconds:02}")
+    } else if hours > 0 {
+        format!("{hours:02}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes:02}:{seconds:02}")
+    }
+}
+
+/// Extract port number from an address field like "*:3000", "127.0.0.1:8080", "[::1]:5173"
 fn extract_port(name_field: &str) -> Option<u16> {
     name_field.rsplit(':').next()?.parse().ok()
 }
@@ -954,6 +1219,11 @@ fn is_dev_process(process_name: &str) -> bool {
         "kernel_tas", "launchd", "mdworker", "mds_store", "cfprefsd",
         "coreaudio", "corebrigh", "airportd", "bluetoothd", "sharingd",
         "usernoted", "notificat", "cloudd",
+        // Windows system/desktop processes
+        "svchost", "system", "lsass", "wininit", "services", "spoolsv",
+        "searchhost", "runtimebroker", "msedge", "onedrive", "steam",
+        "nvcontainer", "widgets", "memcompression", "dwm", "csrss",
+        "explorer", "sihost", "taskhostw", "dllhost", "conhost",
     ];
     for app in &system_apps {
         if name.starts_with(app) { return false; }
@@ -1029,31 +1299,65 @@ fn detect_framework(process: &str, cmdline: &str, project_root: &str) -> String 
 
 fn match_project(cwd: &str, repo_paths: &[String]) -> String {
     if cwd.is_empty() { return String::new(); }
+
+    // NTFS is case-insensitive and paths arrive with mixed separators, so
+    // normalize before the prefix comparison on Windows.
+    #[cfg(windows)]
+    fn norm(path: &str) -> String {
+        path.replace('\\', "/").to_ascii_lowercase()
+    }
+    #[cfg(not(windows))]
+    fn norm(path: &str) -> String {
+        path.to_string()
+    }
+
+    let cwd_norm = norm(cwd);
     repo_paths
         .iter()
-        .filter(|repo| cwd.starts_with(repo.as_str()))
+        .filter(|repo| cwd_norm.starts_with(&norm(repo)))
         .max_by_key(|repo| repo.len())
-        .and_then(|repo| repo.rsplit('/').next())
+        .and_then(|repo| Path::new(repo).file_name().and_then(|n| n.to_str()))
         .unwrap_or("")
         .to_string()
 }
 
 #[tauri::command]
 pub async fn kill_port(pid: u32) -> Result<(), String> {
-    // SIGTERM first, then SIGKILL if needed
     let pid_str = pid.to_string();
-    let status = Command::new("kill")
-        .arg(&pid_str)
-        .status()
-        .map_err(|e| format!("Failed to kill process {pid}: {e}"))?;
 
-    if !status.success() {
-        Command::new("kill")
-            .args(["-9", &pid_str])
+    // Graceful first, then force-kill (with the child tree) if needed
+    #[cfg(windows)]
+    {
+        let status = crate::util::quiet_command("taskkill")
+            .args(["/PID", &pid_str, "/T"])
             .status()
-            .map_err(|e| format!("Failed to force-kill process {pid}: {e}"))?;
+            .map_err(|e| format!("Failed to kill process {pid}: {e}"))?;
+
+        if !status.success() {
+            crate::util::quiet_command("taskkill")
+                .args(["/F", "/T", "/PID", &pid_str])
+                .status()
+                .map_err(|e| format!("Failed to force-kill process {pid}: {e}"))?;
+        }
+        Ok(())
     }
-    Ok(())
+
+    // SIGTERM first, then SIGKILL if needed
+    #[cfg(not(windows))]
+    {
+        let status = Command::new("kill")
+            .arg(&pid_str)
+            .status()
+            .map_err(|e| format!("Failed to kill process {pid}: {e}"))?;
+
+        if !status.success() {
+            Command::new("kill")
+                .args(["-9", &pid_str])
+                .status()
+                .map_err(|e| format!("Failed to force-kill process {pid}: {e}"))?;
+        }
+        Ok(())
+    }
 }
 
 // ── Pi config commands ─────────────────────────────────────────────

--- a/src-tauri/src/fonts/macos.rs
+++ b/src-tauri/src/fonts/macos.rs
@@ -1,22 +1,15 @@
 //! macOS CoreText-based font enumeration and resolution.
 //!
-//! Two public entry points:
-//!
-//! - [`list_monospace_families`] enumerates every installed font family that
-//!   advertises the `kCTFontMonoSpaceTrait` symbolic trait. Result is cached in
-//!   a `OnceLock` because enumeration walks every installed font and only
-//!   changes when the user installs/removes fonts (an app restart recovers).
+//! - [`enumerate_monospace_families`] enumerates every installed font family
+//!   that advertises the `kCTFontMonoSpaceTrait` symbolic trait.
 //!
 //! - [`load_font_family`] resolves a family name to all of its on-disk faces
 //!   via `CTFontCollectionCreateForFamily`, reads the raw font file bytes, and
 //!   extracts CSS-compatible weight/italic/stretch values from the descriptor's
-//!   traits attribute dictionary. The frontend passes each face to the
-//!   `FontFace` constructor with proper descriptors so the browser does not
-//!   synthesize bold/italic variants.
+//!   traits attribute dictionary.
 
 use std::fs;
 use std::path::PathBuf;
-use std::sync::OnceLock;
 
 use core_foundation::{
     array::{CFArray, CFArrayRef},
@@ -30,7 +23,8 @@ use core_text::{
     font_collection,
     font_descriptor::{kCTFontTraitsAttribute, kCTFontURLAttribute, CTFontDescriptor},
 };
-use serde::Serialize;
+
+use super::{is_nerd_font_name, FontFaceData, FontFamily};
 
 // Raw CTFontDescriptor pointer, for the FFI signatures below. Equivalent to
 // `CTFontDescriptorRef` in the CoreText C headers.
@@ -62,40 +56,7 @@ extern "C" {
 /// Bit set in `kCTFontSymbolicTrait` when the font is monospace.
 const MONO_SPACE_TRAIT: u32 = 1 << 10;
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FontFamily {
-    pub family: String,
-    pub face_count: usize,
-    pub is_nerd_font: bool,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FontFaceData {
-    /// Raw TTF/OTF bytes read from disk.
-    pub data: Vec<u8>,
-    /// CSS font-weight value in the 100..=900 range.
-    pub weight: u16,
-    /// Whether the face is italic or oblique.
-    pub italic: bool,
-    /// CSS font-stretch keyword index (1 = ultra-condensed .. 9 = ultra-expanded).
-    pub stretch: u16,
-}
-
-/// Cached list of installed monospace families. Populated once per process.
-static MONO_FAMILIES: OnceLock<Vec<FontFamily>> = OnceLock::new();
-
-/// Return the cached list of installed monospace families, enumerating on
-/// first call. The result is stable for the lifetime of the process; an app
-/// restart is required to pick up newly-installed fonts.
-pub fn list_monospace_families() -> Vec<FontFamily> {
-    MONO_FAMILIES
-        .get_or_init(enumerate_monospace_families)
-        .clone()
-}
-
-fn enumerate_monospace_families() -> Vec<FontFamily> {
+pub fn enumerate_monospace_families() -> Vec<FontFamily> {
     let family_names = all_family_names();
     let mut result: Vec<FontFamily> = Vec::with_capacity(family_names.len());
 
@@ -131,13 +92,6 @@ fn enumerate_monospace_families() -> Vec<FontFamily> {
         });
     }
 
-    // Nerd Fonts first, then alphabetical within each group. Developers
-    // overwhelmingly want Nerd Font variants for powerline/devicons.
-    result.sort_by(|a, b| {
-        b.is_nerd_font
-            .cmp(&a.is_nerd_font)
-            .then_with(|| a.family.to_lowercase().cmp(&b.family.to_lowercase()))
-    });
     result
 }
 
@@ -150,11 +104,6 @@ fn all_family_names() -> Vec<String> {
         let array: CFArray<CFString> = CFArray::wrap_under_create_rule(array_ref);
         array.iter().map(|s| s.to_string()).collect()
     }
-}
-
-fn is_nerd_font_name(name: &str) -> bool {
-    let lower = name.to_lowercase();
-    lower.contains("nerd font") || lower.contains("nerdfont")
 }
 
 /// Resolve a font family name to every on-disk face. Returns an empty vec if

--- a/src-tauri/src/fonts/mod.rs
+++ b/src-tauri/src/fonts/mod.rs
@@ -1,0 +1,106 @@
+//! Cross-platform font enumeration and resolution.
+//!
+//! Two public entry points:
+//!
+//! - [`list_monospace_families`] enumerates every installed font family that
+//!   contains at least one monospace face. Result is cached in a `OnceLock`
+//!   because enumeration walks every installed font and only changes when the
+//!   user installs/removes fonts (an app restart recovers).
+//!
+//! - [`load_font_family`] resolves a family name to all of its on-disk faces,
+//!   reads the raw font file bytes, and extracts CSS-compatible weight/italic/
+//!   stretch values. The frontend passes each face to the `FontFace`
+//!   constructor with proper descriptors so the browser does not synthesize
+//!   bold/italic variants.
+//!
+//! The macOS backend uses CoreText; the Windows backend uses `fontdb`
+//! (which parses the installed font files directly). Both produce the same
+//! wire shapes so the frontend needs no platform awareness.
+
+use std::sync::OnceLock;
+
+use serde::Serialize;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+use macos as backend;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows as backend;
+
+#[cfg(not(any(target_os = "macos", windows)))]
+mod fallback {
+    use super::{FontFaceData, FontFamily};
+
+    pub fn enumerate_monospace_families() -> Vec<FontFamily> {
+        Vec::new()
+    }
+
+    pub fn load_font_family(_family: &str) -> Vec<FontFaceData> {
+        Vec::new()
+    }
+}
+#[cfg(not(any(target_os = "macos", windows)))]
+use fallback as backend;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FontFamily {
+    pub family: String,
+    pub face_count: usize,
+    pub is_nerd_font: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FontFaceData {
+    /// Raw TTF/OTF bytes read from disk.
+    pub data: Vec<u8>,
+    /// CSS font-weight value in the 100..=900 range.
+    pub weight: u16,
+    /// Whether the face is italic or oblique.
+    pub italic: bool,
+    /// CSS font-stretch keyword index (1 = ultra-condensed .. 9 = ultra-expanded).
+    pub stretch: u16,
+}
+
+/// Cached list of installed monospace families. Populated once per process.
+static MONO_FAMILIES: OnceLock<Vec<FontFamily>> = OnceLock::new();
+
+/// Return the cached list of installed monospace families, enumerating on
+/// first call. The result is stable for the lifetime of the process; an app
+/// restart is required to pick up newly-installed fonts.
+pub fn list_monospace_families() -> Vec<FontFamily> {
+    MONO_FAMILIES
+        .get_or_init(|| {
+            let mut result = backend::enumerate_monospace_families();
+            // Nerd Fonts first, then alphabetical within each group. Developers
+            // overwhelmingly want Nerd Font variants for powerline/devicons.
+            result.sort_by(|a, b| {
+                b.is_nerd_font
+                    .cmp(&a.is_nerd_font)
+                    .then_with(|| a.family.to_lowercase().cmp(&b.family.to_lowercase()))
+            });
+            result
+        })
+        .clone()
+}
+
+/// Resolve a font family name to every on-disk face. Returns an empty vec if
+/// the family is not installed or cannot be read.
+pub fn load_font_family(family: &str) -> Vec<FontFaceData> {
+    backend::load_font_family(family)
+}
+
+/// Nerd Fonts register under their full name ("JetBrainsMono Nerd Font") or,
+/// especially on Windows, the abbreviated "NF" suffix form ("JetBrainsMono NF").
+pub(crate) fn is_nerd_font_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("nerd font")
+        || lower.contains("nerdfont")
+        || lower.ends_with(" nf")
+        || lower.contains(" nf ")
+}

--- a/src-tauri/src/fonts/windows.rs
+++ b/src-tauri/src/fonts/windows.rs
@@ -1,0 +1,105 @@
+//! Windows font enumeration and resolution, backed by `fontdb`.
+//!
+//! `fontdb` walks the system font directories (`C:\Windows\Fonts` plus the
+//! per-user font store) and parses each face with `ttf-parser`, exposing the
+//! family name, CSS-style weight/stretch, italic style, monospace flag, and
+//! the on-disk source path — everything the shared wire contract needs.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use fontdb::{Database, Source, Stretch, Style};
+
+use super::{is_nerd_font_name, FontFaceData, FontFamily};
+
+/// Parsed system font database. Built once per process; an app restart is
+/// required to pick up newly-installed fonts (same contract as macOS).
+static FONT_DB: OnceLock<Database> = OnceLock::new();
+
+fn font_db() -> &'static Database {
+    FONT_DB.get_or_init(|| {
+        let mut db = Database::new();
+        db.load_system_fonts();
+        db
+    })
+}
+
+pub fn enumerate_monospace_families() -> Vec<FontFamily> {
+    // family name -> (face_count, has_mono_face)
+    let mut families: HashMap<&str, (usize, bool)> = HashMap::new();
+
+    for face in font_db().faces() {
+        let Some((name, _)) = face.families.first() else {
+            continue;
+        };
+        let entry = families.entry(name.as_str()).or_insert((0, false));
+        entry.0 += 1;
+        if face.monospaced {
+            entry.1 = true;
+        }
+    }
+
+    families
+        .into_iter()
+        .filter(|(_, (face_count, has_mono_face))| *has_mono_face && *face_count > 0)
+        .map(|(family, (face_count, _))| FontFamily {
+            family: family.to_string(),
+            face_count,
+            is_nerd_font: is_nerd_font_name(family),
+        })
+        .collect()
+}
+
+/// Resolve a font family name to every on-disk face. Returns an empty vec if
+/// the family is not installed or cannot be read. Dedupes by canonical file
+/// path (matching the macOS backend's behavior for .ttc collections).
+pub fn load_font_family(family: &str) -> Vec<FontFaceData> {
+    let mut seen_paths: HashSet<PathBuf> = HashSet::new();
+    let mut result: Vec<FontFaceData> = Vec::new();
+
+    for face in font_db().faces() {
+        if !face.families.iter().any(|(name, _)| name == family) {
+            continue;
+        }
+
+        let path = match &face.source {
+            Source::File(path) | Source::SharedFile(path, _) => path,
+            Source::Binary(_) => continue,
+        };
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
+        if !seen_paths.insert(canonical.clone()) {
+            continue;
+        }
+
+        let Ok(data) = fs::read(&canonical) else {
+            continue;
+        };
+
+        result.push(FontFaceData {
+            data,
+            weight: face.weight.0.clamp(100, 900),
+            italic: matches!(face.style, Style::Italic | Style::Oblique),
+            stretch: stretch_index(face.stretch),
+        });
+    }
+
+    result
+}
+
+/// Map a `fontdb::Stretch` to the CSS font-stretch keyword index used by the
+/// wire contract (1 = ultra-condensed, 5 = normal, 9 = ultra-expanded).
+fn stretch_index(stretch: Stretch) -> u16 {
+    match stretch {
+        Stretch::UltraCondensed => 1,
+        Stretch::ExtraCondensed => 2,
+        Stretch::Condensed => 3,
+        Stretch::SemiCondensed => 4,
+        Stretch::Normal => 5,
+        Stretch::SemiExpanded => 6,
+        Stretch::Expanded => 7,
+        Stretch::ExtraExpanded => 8,
+        Stretch::UltraExpanded => 9,
+    }
+}

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -2,6 +2,20 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use std::process::Command;
 
+use crate::util::quiet_command;
+
+/// Build a `git` invocation. Routed through `quiet_command` so the frequent
+/// status/diff polling never flashes console windows on Windows.
+fn git_cmd() -> Command {
+    quiet_command("git")
+}
+
+/// Null-device diff operand for untracked-file diffs.
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_DEVICE: &str = "/dev/null";
+
 #[derive(serde::Serialize, Clone, Default)]
 pub struct GitStatus {
     pub is_git_repo: bool,
@@ -17,7 +31,7 @@ pub struct GitStatus {
 }
 
 pub fn status(path: &str) -> GitStatus {
-    let output = match Command::new("git")
+    let output = match git_cmd()
         .args(["-C", path, "status", "--porcelain=v2", "--branch"])
         .output()
     {
@@ -69,7 +83,7 @@ pub fn status(path: &str) -> GitStatus {
     let git_path = std::path::Path::new(path).join(".git");
     let worktree_parent = if git_path.is_file() {
         // This is a worktree — resolve the main repo path via git-common-dir
-        Command::new("git")
+        git_cmd()
             .args(["-C", path, "rev-parse", "--git-common-dir"])
             .output()
             .ok()
@@ -104,7 +118,7 @@ pub fn status(path: &str) -> GitStatus {
 }
 
 pub fn is_git_repo(path: &str) -> bool {
-    Command::new("git")
+    git_cmd()
         .args(["-C", path, "rev-parse", "--git-dir"])
         .output()
         .map(|o| o.status.success())
@@ -112,7 +126,7 @@ pub fn is_git_repo(path: &str) -> bool {
 }
 
 pub fn init_repo(path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "init", "-b", "main"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -123,7 +137,7 @@ pub fn init_repo(path: &str) -> Result<(), String> {
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     if stderr.contains("unknown switch `b'") || stderr.contains("unknown option `b'") {
-        let fallback = Command::new("git")
+        let fallback = git_cmd()
             .args(["-C", path, "init"])
             .output()
             .map_err(|e| e.to_string())?;
@@ -139,7 +153,7 @@ pub fn init_repo(path: &str) -> Result<(), String> {
 }
 
 pub fn current_branch(path: &str) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "branch", "--show-current"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -152,7 +166,7 @@ pub fn current_branch(path: &str) -> Result<String, String> {
 }
 
 pub fn list_branches(path: &str) -> Result<Vec<String>, String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "branch", "--format=%(refname:short)"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -171,7 +185,7 @@ pub fn list_branches(path: &str) -> Result<Vec<String>, String> {
 }
 
 pub fn push_branch(path: &str, branch: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "push", "-u", "origin", branch])
         .output()
         .map_err(|e| e.to_string())?;
@@ -199,7 +213,7 @@ pub struct CreatedWorktree {
 }
 
 pub fn list_worktrees(path: &str) -> Result<Vec<WorktreeEntry>, String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "worktree", "list", "--porcelain"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -215,8 +229,9 @@ pub fn list_worktrees(path: &str) -> Result<Vec<WorktreeEntry>, String> {
 
     for line in stdout.lines() {
         if let Some(rest) = line.strip_prefix("worktree ") {
-            let canonical_path = Path::new(rest)
-                .canonicalize()
+            // dunce keeps the canonical form free of \\?\ verbatim prefixes on
+            // Windows so worktree paths string-match registered repo paths.
+            let canonical_path = dunce::canonicalize(Path::new(rest))
                 .unwrap_or_else(|_| Path::new(rest).to_path_buf())
                 .to_string_lossy()
                 .to_string();
@@ -254,7 +269,7 @@ pub fn create_worktree(path: &str, branch_name: &str) -> Result<CreatedWorktree,
         return Err("Branch name is required".to_string());
     }
 
-    let validate = Command::new("git")
+    let validate = git_cmd()
         .args(["-C", path, "check-ref-format", "--branch", branch_name])
         .output()
         .map_err(|e| e.to_string())?;
@@ -270,15 +285,18 @@ pub fn create_worktree(path: &str, branch_name: &str) -> Result<CreatedWorktree,
     // Always derive the output path from the main repo, not the calling worktree,
     // so all worktrees end up in the same .shep-worktrees/<repo>/ directory.
     let main_repo_path = {
-        let out = Command::new("git")
+        let out = git_cmd()
             .args(["-C", path, "worktree", "list", "--porcelain"])
             .output()
             .map_err(|e| format!("Failed to list worktrees: {e}"))?;
         let stdout = String::from_utf8_lossy(&out.stdout);
-        stdout
+        let porcelain_path = stdout
             .lines()
             .find_map(|l| l.strip_prefix("worktree ").map(|p| std::path::PathBuf::from(p.trim())))
-            .ok_or_else(|| "Could not determine main repo path".to_string())?
+            .ok_or_else(|| "Could not determine main repo path".to_string())?;
+        // Git porcelain emits forward-slash paths on Windows; normalize to the
+        // same canonical form the rest of the app stores.
+        dunce::canonicalize(&porcelain_path).unwrap_or(porcelain_path)
     };
 
     let repo_name = main_repo_path
@@ -304,6 +322,21 @@ pub fn create_worktree(path: &str, branch_name: &str) -> Result<CreatedWorktree,
         branch_slug
     };
 
+    // Windows reserves device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9) as
+    // path components; suffix the slug so the directory stays creatable.
+    let branch_slug = {
+        let lower = branch_slug.to_ascii_lowercase();
+        let reserved = matches!(lower.as_str(), "con" | "prn" | "aux" | "nul")
+            || (lower.len() == 4
+                && (lower.starts_with("com") || lower.starts_with("lpt"))
+                && lower[3..].chars().all(|c| c.is_ascii_digit()));
+        if reserved {
+            format!("{branch_slug}-wt")
+        } else {
+            branch_slug
+        }
+    };
+
     let worktree_path = repo_parent
         .join(".shep-worktrees")
         .join(repo_name)
@@ -319,7 +352,7 @@ pub fn create_worktree(path: &str, branch_name: &str) -> Result<CreatedWorktree,
     }
 
     let worktree_path_string = worktree_path.to_string_lossy().to_string();
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "worktree", "add", "-b", branch_name, &worktree_path_string])
         .output()
         .map_err(|e| e.to_string())?;
@@ -327,6 +360,13 @@ pub fn create_worktree(path: &str, branch_name: &str) -> Result<CreatedWorktree,
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
+
+    // Canonicalize now that the directory exists so the returned path matches
+    // the form `git worktree list` and registered repos use.
+    let worktree_path_string = dunce::canonicalize(&worktree_path)
+        .unwrap_or(worktree_path)
+        .to_string_lossy()
+        .to_string();
 
     Ok(CreatedWorktree {
         path: worktree_path_string,
@@ -350,7 +390,7 @@ pub fn changed_files(path: &str) -> Result<Vec<ChangedFile>, String> {
     // single directory entry when a whole folder is untracked, and that
     // trailing-slash "folder" leaks into our file list. Gitignored files
     // inside the directory are still excluded.
-    let output = Command::new("git")
+    let output = git_cmd()
         .args([
             "-C",
             path,
@@ -496,7 +536,7 @@ fn decode_preview_bytes(bytes: Vec<u8>, file_path: &str) -> Result<String, Strin
 /// `.env`, `.env.*`, and `.envrc` files so common local config remains
 /// inspectable even when ignored by git.
 pub fn list_files(path: &str) -> Result<Vec<String>, String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args([
             "-C",
             path,
@@ -566,7 +606,7 @@ pub fn file_contents(path: &str, file_path: &str, source: &str) -> Result<String
             } else {
                 format!("HEAD:{file_path}")
             };
-            let output = Command::new("git")
+            let output = git_cmd()
                 .args(["-C", path, "show", &spec])
                 .output()
                 .map_err(|e| e.to_string())?;
@@ -588,26 +628,26 @@ pub fn file_contents(path: &str, file_path: &str, source: &str) -> Result<String
 
 pub fn file_diff(path: &str, file_path: &str, staged: bool) -> Result<String, String> {
     let output = if staged {
-        Command::new("git")
+        git_cmd()
             .args(["-C", path, "diff", "--cached", "--", file_path])
             .output()
             .map_err(|e| e.to_string())?
     } else {
         // Try normal diff first
-        let result = Command::new("git")
+        let result = git_cmd()
             .args(["-C", path, "diff", "--", file_path])
             .output()
             .map_err(|e| e.to_string())?;
 
         if result.status.success() && result.stdout.is_empty() {
-            // Might be untracked — use diff against /dev/null
-            Command::new("git")
+            // Might be untracked — use diff against the null device
+            git_cmd()
                 .args([
                     "-C",
                     path,
                     "diff",
                     "--no-index",
-                    "/dev/null",
+                    NULL_DEVICE,
                     file_path,
                 ])
                 .output()
@@ -649,7 +689,7 @@ fn parse_numstat_line(line: &str, fallback_path: Option<&str>) -> Option<DiffFil
 /// --numstat` (all changes vs HEAD) so staged and unstaged changes are combined.
 /// Falls back to `--cached` on repos with no HEAD yet (first commit pending).
 pub fn diff_stats(path: &str) -> Result<Vec<DiffFileStat>, String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "diff", "HEAD", "--numstat"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -657,7 +697,7 @@ pub fn diff_stats(path: &str) -> Result<Vec<DiffFileStat>, String> {
     let stdout = if output.status.success() {
         String::from_utf8_lossy(&output.stdout).to_string()
     } else {
-        let cached = Command::new("git")
+        let cached = git_cmd()
             .args(["-C", path, "diff", "--cached", "--numstat"])
             .output()
             .map_err(|e| e.to_string())?;
@@ -676,14 +716,14 @@ pub fn diff_stats(path: &str) -> Result<Vec<DiffFileStat>, String> {
         .into_iter()
         .filter(|file| file.area == "untracked")
     {
-        let output = Command::new("git")
+        let output = git_cmd()
             .args([
                 "-C",
                 path,
                 "diff",
                 "--no-index",
                 "--numstat",
-                "/dev/null",
+                NULL_DEVICE,
                 &file.path,
             ])
             .output()
@@ -705,7 +745,7 @@ pub fn diff_stats(path: &str) -> Result<Vec<DiffFileStat>, String> {
 }
 
 pub fn stage_file(path: &str, file_path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "add", "--", file_path])
         .output()
         .map_err(|e| e.to_string())?;
@@ -718,7 +758,7 @@ pub fn stage_file(path: &str, file_path: &str) -> Result<(), String> {
 }
 
 pub fn stage_all(path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "add", "-A"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -731,7 +771,7 @@ pub fn stage_all(path: &str) -> Result<(), String> {
 }
 
 pub fn commit(path: &str, message: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "commit", "-m", message])
         .output()
         .map_err(|e| e.to_string())?;
@@ -744,7 +784,7 @@ pub fn commit(path: &str, message: &str) -> Result<(), String> {
 }
 
 pub fn unstage_file(path: &str, file_path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "restore", "--staged", "--", file_path])
         .output()
         .map_err(|e| e.to_string())?;
@@ -757,7 +797,7 @@ pub fn unstage_file(path: &str, file_path: &str) -> Result<(), String> {
 }
 
 pub fn unstage_all(path: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "restore", "--staged", "."])
         .output()
         .map_err(|e| e.to_string())?;
@@ -770,7 +810,7 @@ pub fn unstage_all(path: &str) -> Result<(), String> {
 }
 
 pub fn switch_branch(path: &str, branch_name: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "switch", branch_name])
         .output()
         .map_err(|e| e.to_string())?;
@@ -783,7 +823,7 @@ pub fn switch_branch(path: &str, branch_name: &str) -> Result<(), String> {
 }
 
 pub fn create_branch(path: &str, branch_name: &str) -> Result<(), String> {
-    let output = Command::new("git")
+    let output = git_cmd()
         .args(["-C", path, "switch", "-c", branch_name])
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod pty;
 mod skills;
 mod todos;
 mod usage;
+mod util;
 mod watcher;
 mod workspace;
 
@@ -108,6 +109,7 @@ pub fn run() {
             commands::kill_pty,
             commands::get_pty_session_count,
             commands::shutdown_and_quit,
+            commands::prepare_for_update,
             commands::get_username,
             commands::get_home_directory,
             commands::get_default_shell,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,6 +1,21 @@
+#[cfg(not(windows))]
 use tauri::menu::{AboutMetadataBuilder, MenuBuilder, MenuItem, SubmenuBuilder, HELP_SUBMENU_ID};
+#[cfg(not(windows))]
 use tauri::{AppHandle, Emitter, Wry};
+#[cfg(windows)]
+use tauri::{AppHandle, Wry};
 
+/// Windows has no native menu: the window is frameless with a custom titlebar
+/// (a Win32 menu strip would render above it), and native menu accelerators
+/// are translated before the webview sees keystrokes, which would steal
+/// Ctrl-key chords from the terminal. App shortcuts are handled by a keydown
+/// listener in the frontend instead (AppShell.tsx), emitting the same actions.
+#[cfg(windows)]
+pub fn setup(_app: &AppHandle<Wry>) -> tauri::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(windows))]
 pub fn setup(app: &AppHandle<Wry>) -> tauri::Result<()> {
     let version = app.config().version.clone();
 

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::process::Command;
 
 use serde::{Deserialize, Serialize};
@@ -145,6 +146,7 @@ pub fn save_pi_settings(settings: PiSettings) -> Result<(), String> {
     fs::write(&path, json).map_err(|e| format!("Failed to write pi settings: {e}"))
 }
 
+#[cfg(target_os = "macos")]
 pub fn save_pi_api_key(provider: &str, api_key: &str) -> Result<(), String> {
     validate_provider_id(provider)?;
     let service = format!("shep-pi-{provider}");
@@ -174,6 +176,17 @@ pub fn save_pi_api_key(provider: &str, api_key: &str) -> Result<(), String> {
     )
 }
 
+/// On non-macOS platforms there is no Keychain-backed `!command` reference the
+/// pi CLI can execute, so store the key directly in auth.json (a plain
+/// `api_key` entry, which pi supports natively). The file lives in the user's
+/// home directory with default user-only ACLs.
+#[cfg(not(target_os = "macos"))]
+pub fn save_pi_api_key(provider: &str, api_key: &str) -> Result<(), String> {
+    validate_provider_id(provider)?;
+    update_auth_entry(provider, api_key)
+}
+
+#[cfg(target_os = "macos")]
 pub fn delete_pi_api_key(provider: &str) -> Result<(), String> {
     validate_provider_id(provider)?;
     let service = format!("shep-pi-{provider}");
@@ -183,6 +196,12 @@ pub fn delete_pi_api_key(provider: &str) -> Result<(), String> {
         .args(["delete-generic-password", "-a", "shep-pi", "-s", &service])
         .output();
 
+    remove_auth_entry(provider)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn delete_pi_api_key(provider: &str) -> Result<(), String> {
+    validate_provider_id(provider)?;
     remove_auth_entry(provider)
 }
 

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -2,10 +2,12 @@ use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, Pt
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
+#[cfg(unix)]
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+#[cfg(unix)]
 use std::time::Duration;
 use tauri::ipc::Channel;
 
@@ -297,6 +299,7 @@ fn decode_utf8_chunks(pending: &mut Vec<u8>, incoming: &[u8]) -> Vec<String> {
 
 /// Find all descendant PIDs of the given root PID by walking the process tree.
 /// Uses `pgrep -P <pid>` to find direct children, then recurses.
+#[cfg(unix)]
 fn get_all_descendants(root_pid: i32) -> Vec<i32> {
     let mut descendants = Vec::new();
     let mut queue = vec![root_pid];
@@ -343,27 +346,54 @@ impl PtySession {
             })
             .map_err(|e| format!("Failed to open PTY: {e}"))?;
 
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-        let mut cmd = CommandBuilder::new(&shell);
-        cmd.arg("-l");
-        cmd.arg("-i");
-        cmd.arg("-c");
-        if let Some(args) = args {
-            cmd.arg("exec \"$@\"");
-            cmd.arg("shep");
-            cmd.arg(command);
-            for arg in args {
-                cmd.arg(arg);
+        #[cfg(unix)]
+        let cmd = {
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+            let mut cmd = CommandBuilder::new(&shell);
+            cmd.arg("-l");
+            cmd.arg("-i");
+            cmd.arg("-c");
+            if let Some(args) = args {
+                cmd.arg("exec \"$@\"");
+                cmd.arg("shep");
+                cmd.arg(command);
+                for arg in args {
+                    cmd.arg(arg);
+                }
+            } else {
+                cmd.arg(command);
             }
-        } else {
+            cmd
+        };
+
+        #[cfg(windows)]
+        let cmd = {
+            // cmd.exe /c is the Windows counterpart of `sh -c`: it parses the
+            // command string and resolves PATH entries including the .cmd/.bat
+            // shims that npm-installed CLIs (claude, codex, ...) ship as.
+            // Unlike macOS, GUI apps inherit the user's full registry-backed
+            // environment, so no login-shell wrapper is needed for PATH.
+            let comspec = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+            let mut cmd = CommandBuilder::new(&comspec);
+            cmd.arg("/c");
             cmd.arg(command);
-        }
+            if let Some(args) = args {
+                for arg in args {
+                    cmd.arg(arg);
+                }
+            }
+            cmd
+        };
+
+        #[allow(unused_mut)]
+        let mut cmd = cmd;
         cmd.cwd(cwd);
 
         for (key, val) in &env {
             cmd.env(key, val);
         }
         cmd.env("TERM", "xterm-256color");
+        #[cfg(not(windows))]
         cmd.env("TERM_PROGRAM", "iTerm.app"); // Fix for CLI tools (like gemini-cli) assuming solid backgrounds
         cmd.env("COLORTERM", "truecolor"); // Enable 24-bit color support
 
@@ -504,6 +534,7 @@ impl PtySession {
             .map_err(|e| format!("Failed to resize PTY: {e}"))
     }
 
+    #[cfg(unix)]
     pub fn kill(&mut self) -> Result<(), String> {
         self.alive.store(false, Ordering::SeqCst);
 
@@ -548,6 +579,26 @@ impl PtySession {
         self.killer
             .kill()
             .map_err(|e| format!("Failed to kill PTY: {e}"))
+    }
+
+    #[cfg(windows)]
+    pub fn kill(&mut self) -> Result<(), String> {
+        self.alive.store(false, Ordering::SeqCst);
+
+        if let Some(pid) = self.child_pid {
+            // taskkill /T walks the whole child tree (cmd.exe -> shell/agent ->
+            // its children) and /F force-terminates — the ConPTY counterpart of
+            // the process-group SIGTERM/SIGKILL escalation used on unix.
+            let _ = crate::util::quiet_command("taskkill")
+                .args(["/T", "/F", "/PID", &pid.to_string()])
+                .output();
+        }
+
+        // Backstop: portable-pty's TerminateProcess on the direct child. It can
+        // report AccessDenied for a process taskkill already reaped, which is
+        // not a failure worth surfacing.
+        let _ = self.killer.kill();
+        Ok(())
     }
 }
 

--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -78,10 +78,12 @@ pub fn read_todos(repo_path: &str) -> Result<Vec<TodoFile>, String> {
             Ok(c) => c,
             Err(_) => continue,
         };
+        // Forward slashes on every platform — this string is display/grouping
+        // data for the frontend, not a filesystem path.
         let relative_path = path
             .strip_prefix(&root)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| path.to_string_lossy().to_string());
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| path.to_string_lossy().replace('\\', "/"));
         let (sections, items) = parse_content(&content);
         files.push(TodoFile {
             path: path.to_string_lossy().to_string(),

--- a/src-tauri/src/usage/helpers.rs
+++ b/src-tauri/src/usage/helpers.rs
@@ -1,13 +1,12 @@
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub fn run_command(program: &str, args: &[&str]) -> Result<String, String> {
-    let mut child = Command::new(program)
+    let mut child = crate::util::quiet_command(program)
         .args(args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/src-tauri/src/usage/ingest.rs
+++ b/src-tauri/src/usage/ingest.rs
@@ -617,7 +617,8 @@ fn estimate_text_tokens(text: &str) -> u64 {
 }
 
 fn project_name_from_path(path: &str) -> String {
-    path.rsplit('/')
+    // Provider logs record native OS paths — backslash-separated on Windows.
+    path.rsplit(['/', '\\'])
         .find(|segment| !segment.is_empty())
         .unwrap_or("unknown")
         .to_string()
@@ -721,14 +722,9 @@ fn ingest_codex_file(conn: &Connection, path: &Path) -> Result<(), String> {
                         .and_then(Value::as_str)
                         .unwrap_or_default()
                         .to_string();
-                    project = payload
-                        .get("cwd")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                        .split('/')
-                        .rfind(|s| !s.is_empty())
-                        .unwrap_or("unknown")
-                        .to_string();
+                    project = project_name_from_path(
+                        payload.get("cwd").and_then(Value::as_str).unwrap_or_default(),
+                    );
                 }
                 if let Some(ts_str) = row.get("timestamp").and_then(Value::as_str) {
                     timestamp = parse_iso_timestamp(ts_str).unwrap_or(0);
@@ -797,10 +793,23 @@ fn ingest_codex_file(conn: &Connection, path: &Path) -> Result<(), String> {
 // ── OpenCode ──────────────────────────────────────────────
 
 fn ingest_opencode(conn: &Connection) -> Result<bool, String> {
-    let db_path = home_join(".local/share/opencode/opencode.db")?;
-    if !db_path.exists() {
-        return Ok(true);
+    // OpenCode defaults to ~/.local/share/opencode on every platform, but
+    // honors XDG_DATA_HOME, and Windows installs may use %LOCALAPPDATA%.
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            candidates.push(std::path::Path::new(&xdg).join("opencode/opencode.db"));
+        }
     }
+    candidates.push(home_join(".local/share/opencode/opencode.db")?);
+    #[cfg(windows)]
+    if let Some(local) = dirs::data_local_dir() {
+        candidates.push(local.join("opencode/opencode.db"));
+    }
+
+    let Some(db_path) = candidates.into_iter().find(|p| p.exists()) else {
+        return Ok(true);
+    };
 
     let cursor_key = "opencode:message-db";
     let meta = fs::metadata(&db_path).map_err(|e| e.to_string())?;
@@ -906,11 +915,7 @@ fn ingest_opencode(conn: &Connection) -> Result<bool, String> {
             .and_then(Value::as_u64)
             .unwrap_or(input + output + thoughts + cache_read + cache_write);
         let recorded_cost = payload.get("cost").and_then(Value::as_f64);
-        let project = directory
-            .split('/')
-            .rfind(|segment| !segment.is_empty())
-            .unwrap_or("unknown")
-            .to_string();
+        let project = project_name_from_path(&directory);
         let timestamp = payload
             .get("time")
             .and_then(|t| t.get("completed").or_else(|| t.get("created")))
@@ -1155,12 +1160,7 @@ fn read_pi_project(path: &Path) -> Option<String> {
     reader.read_line(&mut line).ok()?;
     let row: Value = serde_json::from_str(&line).ok()?;
     let cwd = row.get("cwd").and_then(Value::as_str)?;
-    Some(
-        cwd.rsplit('/')
-            .find(|s| !s.is_empty())
-            .unwrap_or("unknown")
-            .to_string(),
-    )
+    Some(project_name_from_path(cwd))
 }
 
 // ── Maintenance ───────────────────────────────────────────

--- a/src-tauri/src/usage/providers.rs
+++ b/src-tauri/src/usage/providers.rs
@@ -1,7 +1,9 @@
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
+#[cfg(unix)]
 use std::path::Path;
+#[cfg(unix)]
 use std::process::Command;
 
 use super::helpers::{home_join, run_command};
@@ -49,11 +51,24 @@ pub fn codex_provider_windows() -> Result<Vec<UsageWindowSnapshot>, String> {
     ])
 }
 
+/// Read Claude Code OAuth credentials. macOS stores them in the Keychain;
+/// Windows and Linux store the same JSON shape at ~/.claude/.credentials.json.
+#[cfg(target_os = "macos")]
+fn claude_credentials_json() -> Result<String, String> {
+    run_command("security", &["find-generic-password", "-s", "Claude Code-credentials", "-w"])
+}
+
+#[cfg(not(target_os = "macos"))]
+fn claude_credentials_json() -> Result<String, String> {
+    let path = home_join(".claude/.credentials.json")?;
+    fs::read_to_string(&path).map_err(|e| format!("Failed to read Claude credentials file: {e}"))
+}
+
 /// Fetch Claude rate limit windows from Anthropic API.
 pub fn claude_provider_windows() -> Result<(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>), String> {
-    let token_json = run_command("security", &["find-generic-password", "-s", "Claude Code-credentials", "-w"])?;
+    let token_json = claude_credentials_json()?;
     let credentials: Value = serde_json::from_str(&token_json)
-        .map_err(|e| format!("Failed to parse Claude Keychain credentials: {e}"))?;
+        .map_err(|e| format!("Failed to parse Claude credentials: {e}"))?;
     let token = credentials
         .get("claudeAiOauth")
         .and_then(|v| v.get("accessToken"))
@@ -216,6 +231,7 @@ fn antigravity_detect_process() -> Result<AntigravityProcess, String> {
     }
 }
 
+#[cfg(unix)]
 fn antigravity_process_list() -> Result<String, String> {
     let output = Command::new("/bin/ps")
         .args(["-ax", "-o", "pid=,command="])
@@ -231,6 +247,37 @@ fn antigravity_process_list() -> Result<String, String> {
     String::from_utf8(output.stdout)
         .map(|s| s.trim().to_string())
         .map_err(|e| format!("Invalid UTF-8 from /bin/ps: {e}"))
+}
+
+/// Produce the same "PID COMMAND" line format `/bin/ps` emits on unix so the
+/// caller's parsing/flag extraction stays shared.
+#[cfg(windows)]
+fn antigravity_process_list() -> Result<String, String> {
+    use sysinfo::{ProcessesToUpdate, System};
+
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::All, true);
+
+    let mut lines = Vec::new();
+    for (pid, process) in sys.processes() {
+        let mut command = process
+            .cmd()
+            .iter()
+            .map(|part| part.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if command.is_empty() {
+            command = process
+                .exe()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
+        }
+        if command.is_empty() {
+            continue;
+        }
+        lines.push(format!("{} {}", pid.as_u32(), command));
+    }
+    Ok(lines.join("\n"))
 }
 
 fn antigravity_process_kind(command: &str) -> Option<&'static str> {
@@ -291,6 +338,7 @@ fn extract_flag(flag: &str, command: &str) -> Option<String> {
     None
 }
 
+#[cfg(unix)]
 fn antigravity_listening_ports(pid: i64) -> Result<Vec<i64>, String> {
     let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"]
         .into_iter()
@@ -308,6 +356,37 @@ fn antigravity_listening_ports(pid: i64) -> Result<Vec<i64>, String> {
         let rest = &line[colon + 1..];
         let port_raw: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
         let Ok(port) = port_raw.parse::<i64>() else {
+            continue;
+        };
+        if !ports.contains(&port) {
+            ports.push(port);
+        }
+    }
+    ports.sort_unstable();
+    if ports.is_empty() {
+        Err("No Antigravity listening ports found".to_string())
+    } else {
+        Ok(ports)
+    }
+}
+
+#[cfg(windows)]
+fn antigravity_listening_ports(pid: i64) -> Result<Vec<i64>, String> {
+    let output = run_command("netstat", &["-ano"])?;
+    let mut ports = Vec::new();
+    for line in output.lines() {
+        // "  TCP    127.0.0.1:42100    0.0.0.0:0    LISTENING    1234"
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 5 || parts[0] != "TCP" || parts[3] != "LISTENING" {
+            continue;
+        }
+        if parts[4].parse::<i64>() != Ok(pid) {
+            continue;
+        }
+        let Some(colon) = parts[1].rfind(':') else {
+            continue;
+        };
+        let Ok(port) = parts[1][colon + 1..].parse::<i64>() else {
             continue;
         };
         if !ports.contains(&port) {

--- a/src-tauri/src/usage/queries.rs
+++ b/src-tauri/src/usage/queries.rs
@@ -279,7 +279,9 @@ fn resolve_path_alias(path: PathBuf) -> Option<ProjectAliasResolution> {
     } else {
         path
     };
-    let canonical_path = expanded.canonicalize().ok()?;
+    // dunce avoids \\?\ verbatim prefixes on Windows so canonical ids match
+    // path strings produced elsewhere in the app.
+    let canonical_path = dunce::canonicalize(&expanded).ok()?;
     let git_root = find_git_root(canonical_path.clone());
     let canonical_id_path = git_root.as_ref().unwrap_or(&canonical_path);
     Some(ProjectAliasResolution {
@@ -295,7 +297,12 @@ fn resolve_path_alias(path: PathBuf) -> Option<ProjectAliasResolution> {
 fn encoded_home_prefixes() -> Vec<String> {
     let mut prefixes = Vec::new();
     if let Some(home) = dirs::home_dir().and_then(|home| home.to_str().map(str::to_string)) {
-        let encoded_home = home.replace('/', "-");
+        // Claude Code encodes '/', '\' and ':' as '-' when building project
+        // labels (e.g. C:\Users\Josh -> C--Users-Josh on Windows).
+        let encoded_home: String = home
+            .chars()
+            .map(|c| if c == '/' || c == '\\' || c == ':' { '-' } else { c })
+            .collect();
         prefixes.push(format!("{encoded_home}-dev--shep-worktrees-"));
         prefixes.push(format!("{encoded_home}--shep-worktrees-"));
         prefixes.push(format!("{encoded_home}-dev-"));
@@ -317,7 +324,7 @@ fn resolve_project_alias(raw_label: &str) -> ProjectAliasResolution {
         };
     }
 
-    if (label.starts_with('/') || label.starts_with("~/"))
+    if (label.starts_with('/') || label.starts_with("~/") || Path::new(label).is_absolute())
         && resolve_path_alias(PathBuf::from(label)).is_some()
     {
         return resolve_path_alias(PathBuf::from(label)).unwrap();

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,0 +1,18 @@
+use std::ffi::OsStr;
+use std::process::Command;
+
+/// Build a `Command` that never flashes a console window on Windows.
+///
+/// Shep is a GUI-subsystem app; on Windows every console child (git, taskkill,
+/// netstat, curl, ...) gets a fresh visible console unless CREATE_NO_WINDOW is
+/// set. On other platforms this is identical to `Command::new`.
+pub fn quiet_command(program: impl AsRef<OsStr>) -> Command {
+    #[allow(unused_mut)]
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    cmd
+}

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -136,7 +136,10 @@ impl GitWatcher {
     }
 
     pub fn watch(&self, path: &str) -> Result<(), String> {
+        // Normalize so event paths reported by the OS backend prefix-match the
+        // stored root (Windows event paths come back canonical/backslashed).
         let path_buf = PathBuf::from(path);
+        let path_buf = dunce::canonicalize(&path_buf).unwrap_or(path_buf);
         let mut watched = self.watched_paths.lock().unwrap();
 
         if watched.contains(&path_buf) {
@@ -156,6 +159,7 @@ impl GitWatcher {
 
     pub fn unwatch(&self, path: &str) -> Result<(), String> {
         let path_buf = PathBuf::from(path);
+        let path_buf = dunce::canonicalize(&path_buf).unwrap_or(path_buf);
         let mut watched = self.watched_paths.lock().unwrap();
 
         if !watched.remove(&path_buf) {

--- a/src-tauri/src/workspace/loader.rs
+++ b/src-tauri/src/workspace/loader.rs
@@ -185,10 +185,11 @@ pub fn register_repo(repo_path: &str) -> Result<RegisteredRepo, String> {
         return Err(format!("Directory does not exist: {repo_path}"));
     }
 
-    // Add to global config if not already there
+    // Add to global config if not already there. dunce avoids the \\?\
+    // verbatim prefix std canonicalize produces on Windows — this string is
+    // the repo's identity across the whole app (git -C, watcher, UI).
     let mut config = load_global_config()?;
-    let canonical = path
-        .canonicalize()
+    let canonical = dunce::canonicalize(path)
         .map_err(|e| format!("Failed to resolve path: {e}"))?;
     let canonical_str = canonical.to_string_lossy().to_string();
 

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "app": {
+    "windows": [
+      {
+        "title": "Shep",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "fullscreen": false,
+        "dragDropEnabled": false,
+        "transparent": true,
+        "decorations": false
+      }
+    ]
+  },
+  "bundle": {
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      },
+      "nsis": {
+        "installMode": "currentUser",
+        "installerIcon": "icons/icon.ico"
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "windows": {
+        "installMode": "passive"
+      }
+    }
+  }
+}

--- a/src/components/git/codeViewTheme.ts
+++ b/src/components/git/codeViewTheme.ts
@@ -3,7 +3,7 @@ import type { ShepTheme } from "../../lib/themes";
 import { hexLuminance } from "../../lib/themes";
 import { shikiThemeFor } from "../../lib/shikiHighlighter";
 
-export const CODE_VIEW_FONT_STACK = "\"SF Mono\", \"Fira Code\", \"Cascadia Code\", monospace";
+export const CODE_VIEW_FONT_STACK = "\"SF Mono\", \"Fira Code\", \"Cascadia Code\", \"Consolas\", monospace";
 export const CODE_VIEW_FONT_SIZE = "12px";
 export const CODE_VIEW_LINE_HEIGHT = "18px";
 export const CODE_VIEW_LINE_PADDING_X = "14px";

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ import TabBar from "./TabBar";
 import TerminalView from "../terminal/TerminalView";
 import TerminalErrorBoundary from "../terminal/TerminalErrorBoundary";
 import NoticeCenter from "../shared/NoticeCenter";
-import { PanelLeft, PanelRight } from "lucide-react";
+import { Minus, PanelLeft, PanelRight, Square, X } from "lucide-react";
 import { useRepoStore } from "../../stores/useRepoStore";
 import { useCommandStore } from "../../stores/useCommandStore";
 import { useTerminalStore } from "../../stores/useTerminalStore";
@@ -28,6 +28,8 @@ import { useUsageSettingsStore } from "../../stores/useUsageSettingsStore";
 import { useUpdateStore } from "../../stores/useUpdateStore";
 import { initNotifications } from "../../lib/notifications";
 import { getErrorMessage } from "../../lib/errors";
+import { isWindows, modKeyLabel } from "../../lib/platform";
+import { pathBasename } from "../../lib/paths";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 
 import type { CommandConfig, CommandState, TerminalTabData, UnifiedTab, SessionMode, WorkspaceConfig } from "../../lib/types";
@@ -57,7 +59,7 @@ function toCommandConfig(command: CommandState): CommandConfig {
 }
 
 function fallbackWorkspaceName(repoPath: string) {
-  return repoPath.split("/").filter(Boolean).pop() ?? "Project";
+  return pathBasename(repoPath) || "Project";
 }
 
 function PanelLoader() {
@@ -282,7 +284,7 @@ export default function AppShell() {
 
   const handleRemoveProject = useCallback(
     async (repoPath: string) => {
-      const repoName = repoPath.split("/").filter(Boolean).pop() ?? "this project";
+      const repoName = pathBasename(repoPath) || "this project";
       const confirmed = await ask(
         `Remove "${repoName}" from Shep? The files on disk will not be deleted.`,
         { title: "Remove project", kind: "warning", okLabel: "Remove", cancelLabel: "Cancel" },
@@ -610,6 +612,54 @@ export default function AppShell() {
     return () => { unlisten.then((f) => f()); };
   }, [handleNewShell, handleNewAssistant, handleOpenInEditor, pushNotice]);
 
+  // Windows has no native menu (a Win32 menu strip can't sit under the custom
+  // titlebar, and native accelerators would steal Ctrl chords from the
+  // terminal), so app shortcuts are handled here. All chords use Ctrl+Shift —
+  // plain Ctrl+letter is a terminal control character — mirroring Windows
+  // Terminal conventions.
+  useEffect(() => {
+    if (!isWindows) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === ",") {
+        e.preventDefault();
+        e.stopPropagation();
+        useUIStore.getState().toggleSettings();
+        return;
+      }
+      if (!e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return;
+      const dispatch = (action: () => void) => {
+        e.preventDefault();
+        e.stopPropagation();
+        action();
+      };
+      switch (e.key.toLowerCase()) {
+        case "t":
+          dispatch(handleNewShell);
+          break;
+        case "a":
+          dispatch(handleNewAssistant);
+          break;
+        case "m":
+          dispatch(() => useTerminalStore.getState().addPanelTab("commands"));
+          break;
+        case "g":
+          dispatch(() => useTerminalStore.getState().addPanelTab("git"));
+          break;
+        case "b":
+          dispatch(() => useUIStore.getState().toggleSidebar());
+          break;
+        case "e":
+          dispatch(() => {
+            const repoPath = useTerminalStore.getState().activeProjectPath;
+            if (repoPath) handleOpenInEditor(repoPath);
+          });
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [handleNewShell, handleNewAssistant, handleOpenInEditor]);
+
   const showOverlay = settingsActive || usagePanelActive || portsPanelActive;
 
   return (
@@ -628,12 +678,12 @@ export default function AppShell() {
           }
         }}
       >
-        <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-0.5 z-20">
+        <div className={`absolute ${isWindows ? "right-36" : "right-4"} top-1/2 -translate-y-1/2 flex items-center gap-0.5 z-20`}>
           <button
             onClick={(e) => { e.stopPropagation(); useUIStore.getState().toggleSidebar(); }}
             onMouseDown={(e) => e.stopPropagation()}
             className={`p-1 rounded transition-opacity hover:opacity-70 ${sidebarVisible ? "opacity-40" : "opacity-15"}`}
-            title={sidebarVisible ? "Hide sidebar (Cmd+B)" : "Show sidebar (Cmd+B)"}
+            title={sidebarVisible ? `Hide sidebar (${modKeyLabel}+${isWindows ? "Shift+" : ""}B)` : `Show sidebar (${modKeyLabel}+${isWindows ? "Shift+" : ""}B)`}
             aria-label={sidebarVisible ? "Hide sidebar" : "Show sidebar"}
           >
             <PanelLeft size={20} />
@@ -648,6 +698,31 @@ export default function AppShell() {
             <PanelRight size={20} />
           </button>
         </div>
+        {isWindows && (
+          <div className="window-caption" onMouseDown={(e) => e.stopPropagation()}>
+            <button
+              className="window-caption__button"
+              onClick={() => getCurrentWindow().minimize()}
+              aria-label="Minimize"
+            >
+              <Minus size={16} />
+            </button>
+            <button
+              className="window-caption__button"
+              onClick={() => getCurrentWindow().toggleMaximize()}
+              aria-label="Maximize"
+            >
+              <Square size={13} />
+            </button>
+            <button
+              className="window-caption__button window-caption__button--close"
+              onClick={() => getCurrentWindow().close()}
+              aria-label="Close"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="app-shell__frame">

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -8,6 +8,7 @@ import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogo
 import { handleActionKey } from "../../lib/a11y";
 import { useGitStore } from "../../stores/useGitStore";
 import tabKindMeta, { extraActions } from "../../lib/tabKindMeta";
+import { pathBasename } from "../../lib/paths";
 import type { UnifiedTab } from "../../lib/types";
 
 
@@ -115,7 +116,7 @@ export default function TabBar({
     useShallow((s) => ({ activeProjectPath: s.activeProjectPath, projectState: s.activeProjectPath ? s.projectState[s.activeProjectPath] : null })),
   );
   const projectTerminals = projectState;
-  const projectName = activeProjectPath ? activeProjectPath.split("/").pop() : null;
+  const projectName = activeProjectPath ? pathBasename(activeProjectPath) : null;
   const gitStatus = useGitStore((s) => activeProjectPath ? s.projectGitStatus[activeProjectPath] : null);
   const branch = gitStatus?.branch ?? null;
   const branchIconColor = !gitStatus || !gitStatus.is_git_repo

--- a/src/components/session/SessionLauncher.tsx
+++ b/src/components/session/SessionLauncher.tsx
@@ -6,6 +6,7 @@ import { useRepoStore } from "../../stores/useRepoStore";
 import { usePiConfigStore } from "../../stores/usePiConfigStore";
 import { HandMetal, ChevronDown, Check, Info, X } from "lucide-react";
 import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogos";
+import { isMac } from "../../lib/platform";
 import { ASSISTANT_INSTALL_URLS } from "../sidebar/constants";
 
 interface SessionLauncherProps {
@@ -311,8 +312,17 @@ export default function SessionLauncher({ onStartSession }: SessionLauncherProps
                 }}
                 onMouseDown={(e) => e.stopPropagation()}
               >
-                <p className="mb-1"><strong style={{ color: "var(--text-primary)" }}>API keys are stored securely in macOS Keychain</strong></p>
-                <p>Provider config is written to <code style={{ color: "rgb(122, 162, 247)" }}>~/.pi/agent/auth.json</code> as a keychain reference that pi resolves at runtime — your key never sits in plaintext on disk.</p>
+                {isMac ? (
+                  <>
+                    <p className="mb-1"><strong style={{ color: "var(--text-primary)" }}>API keys are stored securely in macOS Keychain</strong></p>
+                    <p>Provider config is written to <code style={{ color: "rgb(122, 162, 247)" }}>~/.pi/agent/auth.json</code> as a keychain reference that pi resolves at runtime — your key never sits in plaintext on disk.</p>
+                  </>
+                ) : (
+                  <>
+                    <p className="mb-1"><strong style={{ color: "var(--text-primary)" }}>API keys are stored in pi's config file</strong></p>
+                    <p>Provider keys are written to <code style={{ color: "rgb(122, 162, 247)" }}>~/.pi/agent/auth.json</code> in your user profile, readable only by your Windows account.</p>
+                  </>
+                )}
               </div>
             )}
           </div>

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { ALL_USAGE_PROVIDERS } from "../usage/usageHelpers";
 import type { CursorStyle, BudgetMode, FontFamily } from "../../lib/types";
 import { getErrorMessage } from "../../lib/errors";
+import { isMac } from "../../lib/platform";
 import { listMonospaceFamilies } from "../../lib/tauri";
 
 interface AppMeta {
@@ -186,8 +187,9 @@ export default function SettingsPanel() {
 
 
   // Assemble the searchable list: always surface the bundled MesloLGS NF
-  // (the default) even if CoreText didn't return it as a system-installed
-  // family, then append everything from Rust. Dedupe by family name.
+  // (the default) even if the OS font enumerator (CoreText/fontdb) didn't
+  // return it as a system-installed family, then append everything from
+  // Rust. Dedupe by family name.
   const pickerFamilies = useMemo(() => {
     const seen = new Set<string>();
     const list: FontFamily[] = [];
@@ -481,7 +483,7 @@ export default function SettingsPanel() {
         <div className="settings-row">
           <span className="settings-row__label flex items-center gap-2">
             <span>Font</span>
-            <InfoTip text="Lists every installed monospace font on your Mac. Nerd Font variants are surfaced first — they're the best choice for powerline prompts and devicons." />
+            <InfoTip text="Lists every installed monospace font on this computer. Nerd Font variants are surfaced first — they're the best choice for powerline prompts and devicons." />
           </span>
           <div className="relative" ref={fontPickerRef}>
             <button
@@ -715,7 +717,7 @@ export default function SettingsPanel() {
           <div className="mb-4">
             <div className="text-sm text-[var(--text-secondary)] mb-2">Update downloaded and ready to install.</div>
             <button className="btn-primary" onClick={() => void restartApp()}>
-              Restart Now
+              {isMac ? "Restart Now" : "Install & Restart"}
             </button>
           </div>
         )}

--- a/src/components/sidebar/ProjectItem.tsx
+++ b/src/components/sidebar/ProjectItem.tsx
@@ -21,6 +21,7 @@ import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useSkillStore } from "../../stores/useSkillStore";
 import { getErrorMessage } from "../../lib/errors";
 import { handleActionKey } from "../../lib/a11y";
+import { fileManagerName } from "../../lib/platform";
 import { gitCreateWorktree, revealInFinder } from "../../lib/tauri";
 import ActivityIndicator, { getAggregateActivityStatus } from "./ActivityIndicator";
 
@@ -196,14 +197,14 @@ export default function ProjectItem({
       onClick: onOpenInEditor,
     },
     {
-      label: "Open in Finder",
+      label: `Open in ${fileManagerName}`,
       icon: <FolderOpen size={14} />,
       onClick: () => {
         revealInFinder(repo.path)
           .catch((error) => {
             pushNotice({
               tone: "error",
-              title: "Couldn't open in Finder",
+              title: `Couldn't open in ${fileManagerName}`,
               message: getErrorMessage(error),
             });
           });

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import SidebarFooter from "./SidebarFooter";
 import SidebarUsage from "./SidebarUsage";
 import AgentSessionList, { type AgentSessionItem } from "./AgentSessionList";
 import SidebarSectionToggle from "./SidebarSectionToggle";
+import { pathBasename } from "../../lib/paths";
 
 interface SidebarProps {
   repos: RepoInfo[];
@@ -109,7 +110,7 @@ export default function Sidebar({
 
     const sessions: AgentSessionItem[] = [];
     for (const [repoPath, state] of Object.entries(projectState)) {
-      const projectName = repoNames.get(repoPath) ?? repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+      const projectName = repoNames.get(repoPath) ?? (pathBasename(repoPath) || repoPath);
       const branchName = gitStatuses[repoPath]?.branch?.trim() || null;
       for (const tab of state.tabs) {
         if (tab.kind !== "assistant") continue;

--- a/src/components/terminal/TerminalView.tsx
+++ b/src/components/terminal/TerminalView.tsx
@@ -22,6 +22,7 @@ import { createTerminalTheme } from "./terminalTheme";
 import { useThemeStore } from "../../stores/useThemeStore";
 import { notifyAgent } from "../../lib/notifications";
 import { KEYBINDING_PRESETS } from "../../lib/keybindingPresets";
+import { isWindows } from "../../lib/platform";
 import { useKeybindingStore } from "../../stores/useKeybindingStore";
 import { useTerminalSettingsStore } from "../../stores/useTerminalSettingsStore";
 
@@ -60,6 +61,9 @@ export default function TerminalView({
       scrollback: termSettings.scrollback,
       allowTransparency: true,
       allowProposedApi: true,
+      // The backend PTY is ConPTY on Windows; without this xterm's reflow and
+      // wrapped-line heuristics scramble output on resize and copy.
+      windowsPty: isWindows ? { backend: "conpty" } : undefined,
       linkHandler: {
         activate: (_ev, url) => {
           void openUrl(url);
@@ -101,6 +105,33 @@ export default function TerminalView({
 
     // Intercept key combos for custom keybindings
     term.attachCustomKeyEventHandler((ev) => {
+      // Windows terminal convention: Ctrl+Shift+C copies the selection,
+      // Ctrl+Shift+V pastes (Cmd+C/Cmd+V never reach the PTY on macOS, but
+      // every plain Ctrl+letter chord is a control character here).
+      if (
+        isWindows &&
+        ev.ctrlKey &&
+        ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey
+      ) {
+        const key = ev.key.toLowerCase();
+        if (key === "c" && term.hasSelection()) {
+          if (ev.type === "keydown") {
+            void navigator.clipboard.writeText(term.getSelection());
+          }
+          return false;
+        }
+        if (key === "v") {
+          if (ev.type === "keydown") {
+            void navigator.clipboard.readText().then((text) => {
+              if (text) term.paste(text);
+            });
+          }
+          return false;
+        }
+      }
+
       const settings = useKeybindingStore.getState().settings;
       for (const preset of KEYBINDING_PRESETS) {
         if (settings[preset.id] && preset.match(ev)) {

--- a/src/hooks/usePty.ts
+++ b/src/hooks/usePty.ts
@@ -11,6 +11,7 @@ import { useNoticeStore } from "../stores/useNoticeStore";
 import { CODING_ASSISTANTS } from "../components/sidebar/constants";
 import type { Terminal } from "@xterm/xterm";
 import { getErrorMessage } from "../lib/errors";
+import { isWindows } from "../lib/platform";
 
 // Map ptyId -> xterm instance for writing output
 const terminalInstances = new Map<number, Terminal>();
@@ -100,7 +101,10 @@ function writeToPty(ptyId: number, data: string) {
 function resolveCommandCwd(repoPath: string, commandCwd: string | null) {
   const trimmed = commandCwd?.trim();
   if (!trimmed) return repoPath;
-  const relativePath = trimmed.replace(/^\.?\//, "").replace(/^\/+/, "");
+  // Normalize backslashes so `.\packages\app` and `./packages/app` are
+  // treated alike, then strip leading ./ and / to force a repo-relative join.
+  const normalized = trimmed.replace(/\\/g, "/").replace(/^[A-Za-z]:/, "");
+  const relativePath = normalized.replace(/^\.?\//, "").replace(/^\/+/, "");
   return `${repoPath}/${relativePath}`;
 }
 
@@ -312,8 +316,9 @@ export function usePty() {
 
       try {
         const shell = await getDefaultShell();
+        // `-l` (login shell) is a unix flag; Windows shells reject it.
         const ptyId = await spawnSession(
-          `${shell} -l`,
+          isWindows ? shell : `${shell} -l`,
           null,
           {},
           cols,

--- a/src/hooks/useThemeApplicator.ts
+++ b/src/hooks/useThemeApplicator.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { getCurrentWindow, Effect, EffectState } from "@tauri-apps/api/window";
+import { isWindows } from "../lib/platform";
 import { useThemeStore } from "../stores/useThemeStore";
 import { applyThemeToTerminals } from "../components/terminal/terminalTheme";
 import { hexLuminance } from "../lib/themes";
@@ -59,8 +60,10 @@ export function useThemeApplicator(): void {
     const win = getCurrentWindow();
     if (theme.isTransparent) {
       document.body.classList.add("theme-clear");
+      // HudWindow is an NSVisualEffectView material (macOS); Windows gets the
+      // DWM equivalents — Tauri applies the first effect the OS supports.
       win.setEffects({
-        effects: [Effect.HudWindow],
+        effects: isWindows ? [Effect.Acrylic, Effect.Blur] : [Effect.HudWindow],
         state: EffectState.Active,
       });
     } else {

--- a/src/lib/fontLoader.ts
+++ b/src/lib/fontLoader.ts
@@ -1,5 +1,6 @@
 import { loadFontFamily } from "./tauri";
 import { TERMINAL_FONT_FAMILY } from "./terminalConfig";
+import { isMac } from "./platform";
 
 /**
  * CSS font-stretch keywords, indexed 1..9 to match the `stretch` value we
@@ -25,13 +26,12 @@ const CSS_STRETCH = [
  */
 const SKIP_FAMILIES = new Set<string>([
   TERMINAL_FONT_FAMILY,
-  "Menlo",
-  "Monaco",
-  "Courier",
-  "Courier New",
-  "Andale Mono",
   "monospace",
   "ui-monospace",
+  "Courier New",
+  ...(isMac
+    ? ["Menlo", "Monaco", "Courier", "Andale Mono"]
+    : ["Consolas", "Cascadia Mono", "Cascadia Code", "Lucida Console"]),
 ]);
 
 /** Families already registered with document.fonts in this session. */

--- a/src/lib/keybindingPresets.ts
+++ b/src/lib/keybindingPresets.ts
@@ -1,4 +1,5 @@
 import type { KeybindingSettings } from "./types";
+import { isMac } from "./platform";
 
 export interface KeybindingPreset {
   id: keyof KeybindingSettings;
@@ -11,6 +12,10 @@ export interface KeybindingPreset {
   match: (ev: KeyboardEvent) => boolean;
 }
 
+// Preset ids are stable across platforms so saved settings survive; only the
+// key combos and labels differ. Windows avoids plain Ctrl+letter chords (they
+// are control characters inside the terminal) and the Win key (reserved by
+// the OS — e.g. Win+K opens the Cast flyout).
 export const KEYBINDING_PRESETS: KeybindingPreset[] = [
   {
     id: "shiftEnterNewline",
@@ -21,22 +26,42 @@ export const KEYBINDING_PRESETS: KeybindingPreset[] = [
     match: (ev) =>
       ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey,
   },
-  {
-    id: "optionDeleteWord",
-    keys: ["\u2325", "Delete"],
-    action: "Delete word",
-    description: "Delete the previous word, matching macOS text editing conventions.",
-    sequence: "\x17", // Ctrl+W
-    match: (ev) =>
-      ev.key === "Backspace" && ev.altKey && !ev.ctrlKey && !ev.metaKey,
-  },
-  {
-    id: "cmdKClear",
-    keys: ["\u2318", "K"],
-    action: "Clear terminal",
-    description: "Clear the terminal screen, matching iTerm and Terminal.app behavior.",
-    sequence: "\x0c", // form feed
-    match: (ev) =>
-      ev.key === "k" && ev.metaKey && !ev.ctrlKey && !ev.altKey,
-  },
+  isMac
+    ? {
+        id: "optionDeleteWord",
+        keys: ["⌥", "Delete"],
+        action: "Delete word",
+        description: "Delete the previous word, matching macOS text editing conventions.",
+        sequence: "\x17", // Ctrl+W
+        match: (ev) =>
+          ev.key === "Backspace" && ev.altKey && !ev.ctrlKey && !ev.metaKey,
+      }
+    : {
+        id: "optionDeleteWord",
+        keys: ["Ctrl", "Backspace"],
+        action: "Delete word",
+        description: "Delete the previous word, matching Windows text editing conventions.",
+        sequence: "\x17", // Ctrl+W
+        match: (ev) =>
+          ev.key === "Backspace" && ev.ctrlKey && !ev.altKey && !ev.metaKey,
+      },
+  isMac
+    ? {
+        id: "cmdKClear",
+        keys: ["⌘", "K"],
+        action: "Clear terminal",
+        description: "Clear the terminal screen, matching iTerm and Terminal.app behavior.",
+        sequence: "\x0c", // form feed
+        match: (ev) =>
+          ev.key === "k" && ev.metaKey && !ev.ctrlKey && !ev.altKey,
+      }
+    : {
+        id: "cmdKClear",
+        keys: ["Ctrl", "Shift", "K"],
+        action: "Clear terminal",
+        description: "Clear the terminal screen.",
+        sequence: "\x0c", // form feed
+        match: (ev) =>
+          ev.key.toLowerCase() === "k" && ev.ctrlKey && ev.shiftKey && !ev.altKey && !ev.metaKey,
+      },
 ];

--- a/src/lib/markdownRenderer.ts
+++ b/src/lib/markdownRenderer.ts
@@ -62,6 +62,6 @@ export function getPlainMarkdownRenderer(): MarkdownIt {
 }
 
 export function isMarkdownFile(filePath: string): boolean {
-  const base = filePath.split("/").pop()?.toLowerCase() ?? "";
+  const base = filePath.split(/[\\/]/).pop()?.toLowerCase() ?? "";
   return base.endsWith(".md") || base.endsWith(".markdown");
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,7 @@
+/**
+ * Separator-agnostic basename: the last non-empty segment of a path.
+ * Handles both `/Users/x/repo` and `C:\Users\x\repo`.
+ */
+export function pathBasename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? "";
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,12 @@
+/**
+ * Platform detection for the webview, evaluated once at module load.
+ * WebView2 user agents contain "Windows"; WKWebView contains "Macintosh".
+ */
+export const isWindows = navigator.userAgent.includes("Windows");
+export const isMac = !isWindows && navigator.userAgent.includes("Mac");
+
+/** Display label for the primary modifier key. */
+export const modKeyLabel = isMac ? "Cmd" : "Ctrl";
+
+/** Platform-appropriate name for the system file manager. */
+export const fileManagerName = isWindows ? "File Explorer" : "Finder";

--- a/src/lib/shikiHighlighter.ts
+++ b/src/lib/shikiHighlighter.ts
@@ -100,7 +100,7 @@ export function shikiThemeFor(theme: ShepTheme): string {
 /** Detect a Shiki language from a file path, or null if unsupported.
  *  Returning null skips the Shiki call entirely and falls back to plain text. */
 export function langForFile(filePath: string): string | null {
-  const base = filePath.split("/").pop() ?? "";
+  const base = filePath.split(/[\\/]/).pop() ?? "";
   const dot = base.lastIndexOf(".");
   if (dot === -1) return null;
   const ext = base.slice(dot + 1).toLowerCase();

--- a/src/lib/tabKindMeta.tsx
+++ b/src/lib/tabKindMeta.tsx
@@ -1,4 +1,5 @@
 import { FolderTree, Terminal, SquareTerminal, List, ListTodo, ExternalLink } from "lucide-react";
+import { isMac } from "./platform";
 import type { TabKind } from "./types";
 
 export interface TabKindMeta {
@@ -7,26 +8,28 @@ export interface TabKindMeta {
   shortcut?: string;
 }
 
+// Windows chords all use Ctrl+Shift (plain Ctrl+letter is a terminal control
+// character) and must match the keydown handler in AppShell.tsx.
 const meta: Record<TabKind, TabKindMeta> = {
   assistant: {
     label: "Agent",
     icon: (size) => <SquareTerminal size={size} />,
-    shortcut: "⇧⌘T",
+    shortcut: isMac ? "⇧⌘T" : "Ctrl+Shift+A",
   },
   terminal: {
     label: "Terminal",
     icon: (size) => <Terminal size={size} />,
-    shortcut: "⌘T",
+    shortcut: isMac ? "⌘T" : "Ctrl+Shift+T",
   },
   commands: {
     label: "Commands",
     icon: (size) => <List size={size} />,
-    shortcut: "⇧⌘C",
+    shortcut: isMac ? "⇧⌘C" : "Ctrl+Shift+M",
   },
   git: {
     label: "Files",
     icon: (size) => <FolderTree size={size} />,
-    shortcut: "⌘G",
+    shortcut: isMac ? "⌘G" : "Ctrl+Shift+G",
   },
   launcher: {
     label: "New Agent",
@@ -43,7 +46,7 @@ export const extraActions = {
   openInEditor: {
     label: "Open in Editor",
     icon: (size: number) => <ExternalLink size={size} />,
-    shortcut: "⌘E",
+    shortcut: isMac ? "⌘E" : "Ctrl+Shift+E",
   },
 } as const;
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -187,6 +187,14 @@ export function shutdownAndQuit(): Promise<void> {
   return invoke("shutdown_and_quit");
 }
 
+export function prepareForUpdate(): Promise<void> {
+  return invoke("prepare_for_update");
+}
+
+export function getPtySessionCount(): Promise<number> {
+  return invoke("get_pty_session_count");
+}
+
 // ── File watcher commands ─────────────────────────────────────────
 
 export function watchRepo(path: string): Promise<void> {

--- a/src/lib/terminalConfig.ts
+++ b/src/lib/terminalConfig.ts
@@ -1,8 +1,21 @@
+import { isMac } from "./platform";
+
 export const TERMINAL_FONT_SIZE = 14;
 export const TERMINAL_FONT_FAMILY = "MesloLGS NF";
 export const TERMINAL_LINE_HEIGHT = 1;
 
-const DEFAULT_FALLBACKS = ["MesloLGS NF", "Menlo", "Monaco", "Courier", "Andale Mono", "monospace"];
+// The bundled MesloLGS NF always resolves first; the rest of the chain covers
+// both macOS (Menlo, Monaco) and Windows (Cascadia Mono, Consolas) so a failed
+// user font never lands on the browser's generic default.
+const DEFAULT_FALLBACKS = [
+  "MesloLGS NF",
+  "Menlo",
+  "Monaco",
+  "Cascadia Mono",
+  "Consolas",
+  "Courier New",
+  "monospace",
+];
 const GENERIC_FAMILIES = new Set([
   "serif",
   "sans-serif",
@@ -19,13 +32,21 @@ const GENERIC_FAMILIES = new Set([
   "fangsong",
 ]);
 
-export const FONT_OPTIONS = [
-  { id: "MesloLGS NF", label: "MesloLGS Nerd Font" },
-  { id: "Menlo", label: "Menlo" },
-  { id: "Monaco", label: "Monaco" },
-  { id: "Courier", label: "Courier" },
-  { id: "Andale Mono", label: "Andale Mono" },
-] as const;
+export const FONT_OPTIONS: readonly { id: string; label: string }[] = isMac
+  ? [
+      { id: "MesloLGS NF", label: "MesloLGS Nerd Font" },
+      { id: "Menlo", label: "Menlo" },
+      { id: "Monaco", label: "Monaco" },
+      { id: "Courier", label: "Courier" },
+      { id: "Andale Mono", label: "Andale Mono" },
+    ]
+  : [
+      { id: "MesloLGS NF", label: "MesloLGS Nerd Font" },
+      { id: "Cascadia Mono", label: "Cascadia Mono" },
+      { id: "Cascadia Code", label: "Cascadia Code" },
+      { id: "Consolas", label: "Consolas" },
+      { id: "Courier New", label: "Courier New" },
+    ];
 
 export const FONT_SIZE_OPTIONS = [12, 13, 14, 15, 16, 18] as const;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { isWindows } from "./lib/platform";
 import "./styles/globals.css";
+
+// Set before first paint so platform-specific CSS (titlebar chrome) applies
+// without a flash of the wrong layout.
+document.documentElement.dataset.platform = isWindows ? "windows" : "mac";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/stores/useUpdateStore.ts
+++ b/src/stores/useUpdateStore.ts
@@ -1,7 +1,10 @@
 import { create } from "zustand";
-import { check, type Update } from "@tauri-apps/plugin-updater";
+import { check, type Update, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { ask } from "@tauri-apps/plugin-dialog";
 import { getErrorMessage } from "../lib/errors";
+import { isWindows } from "../lib/platform";
+import { getPtySessionCount, prepareForUpdate } from "../lib/tauri";
 
 type UpdateStatus =
   | "idle"
@@ -71,21 +74,30 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
     let totalLength = 0;
     let downloaded = 0;
 
-    try {
-      await update.downloadAndInstall((event) => {
-        if (event.event === "Started") {
-          totalLength = event.data.contentLength ?? 0;
-        } else if (event.event === "Progress") {
-          downloaded += event.data.chunkLength;
-          if (totalLength > 0) {
-            set({
-              downloadProgress: Math.round((downloaded / totalLength) * 100),
-            });
-          }
-        } else if (event.event === "Finished") {
-          set({ status: "ready", downloadProgress: 100 });
+    const onProgress = (event: DownloadEvent) => {
+      if (event.event === "Started") {
+        totalLength = event.data.contentLength ?? 0;
+      } else if (event.event === "Progress") {
+        downloaded += event.data.chunkLength;
+        if (totalLength > 0) {
+          set({
+            downloadProgress: Math.round((downloaded / totalLength) * 100),
+          });
         }
-      });
+      } else if (event.event === "Finished") {
+        set({ status: "ready", downloadProgress: 100 });
+      }
+    };
+
+    try {
+      if (isWindows) {
+        // Download only. Installing on Windows launches the installer and
+        // terminates the app immediately, so it happens in restartApp()
+        // after sessions are confirmed and reaped.
+        await update.download(onProgress);
+      } else {
+        await update.downloadAndInstall(onProgress);
+      }
       set({ status: "ready", downloadProgress: 100 });
     } catch (e) {
       set({
@@ -97,6 +109,26 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
   },
 
   restartApp: async () => {
+    if (isWindows) {
+      const update = get()._update;
+      if (!update) return;
+
+      // The installer terminates the app directly, bypassing the
+      // ExitRequested cleanup — confirm and reap child sessions first so no
+      // shells/agents are orphaned holding files the installer needs.
+      const count = await getPtySessionCount().catch(() => 0);
+      if (count > 0) {
+        const confirmed = await ask(
+          `Installing the update will stop ${count} running session${count === 1 ? "" : "s"} and restart Shep. Continue?`,
+          { title: "Install update", kind: "warning", okLabel: "Install", cancelLabel: "Cancel" },
+        );
+        if (!confirmed) return;
+      }
+      await prepareForUpdate();
+      await update.install();
+      return;
+    }
+
     await relaunch();
   },
 }));

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1203,7 +1203,7 @@ select {
   margin-top: 1px;
   font-size: 11px;
   color: var(--text-muted);
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
 }
 
 .command-empty-state {
@@ -1242,7 +1242,7 @@ select {
 }
 
 .command-form__input--code {
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
 }
 
 .command-form__textarea {
@@ -1251,7 +1251,7 @@ select {
   padding: 6px 8px;
   border-radius: var(--radius-sm);
   font-size: 12px;
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
   color: var(--text-primary);
   background: color-mix(in srgb, var(--overlay) 6%, transparent);
   border: 1px solid var(--border-hover);
@@ -1401,6 +1401,37 @@ select {
   color: var(--text-muted);
   pointer-events: none;
   user-select: none;
+}
+
+/* ── Windows caption buttons (frameless window, no traffic lights) ── */
+
+.window-caption {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+  z-index: 30;
+}
+
+.window-caption__button {
+  width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.window-caption__button:hover {
+  background-color: color-mix(in srgb, var(--overlay) 12%, transparent);
+  color: var(--app-fg);
+}
+
+.window-caption__button--close:hover {
+  background-color: #e81123;
+  color: #ffffff;
 }
 
 /* ── Sidebar usage section ─────────────────────────────── */
@@ -2433,7 +2464,7 @@ select {
  * mode toggle) can absolute-position relative to it without fighting
  * the scroll container inside DiffViewer/FileViewer. */
 .git-panel__viewer-area {
-  --code-view-font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  --code-view-font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
   --code-view-font-size: 12px;
   --code-view-line-height: 18px;
   --code-view-line-padding-x: 14px;
@@ -2677,7 +2708,7 @@ select {
 }
 
 .markdown-view__content code {
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
   font-size: 0.92em;
 }
 
@@ -2896,7 +2927,7 @@ select {
 .commands-panel__input--command {
   flex: 1;
   min-width: 0;
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
 }
 
 .commands-panel__auto {
@@ -3137,7 +3168,7 @@ select {
   padding: 4px 8px;
   border-radius: var(--radius-sm);
   font-size: 12px;
-  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
   color: var(--text-primary);
   background: color-mix(in srgb, var(--overlay) 6%, transparent);
   border: 1px solid var(--border-hover);


### PR DESCRIPTION
## Summary

This PR makes Shep fully Windows-compatible with 1:1 feature parity against the macOS version, while leaving macOS behavior untouched (all mac-specific code is preserved under `cfg` gates / platform branches — no mac code paths were modified, only relocated).

Verified on Windows 11:
- `cargo check` clean (previously failed immediately on core-text/core-foundation)
- `cargo test`: 32/32 passing
- `pnpm build` (tsc + vite) clean
- App launches and runs under `pnpm tauri dev` — terminals, PowerShell sessions, git panel all functional
- `pnpm tauri build` produces both bundles: `shep_0.4.0_x64-setup.exe` (NSIS) and `shep_0.4.0_x64_en-US.msi`

## Backend (Rust)

| Area | macOS (unchanged) | Windows (new) |
| --- | --- | --- |
| PTY spawn | `$SHELL -l -i -c` | `cmd.exe /c` (resolves npm `.cmd` shims; GUI apps inherit registry PATH so no login-shell wrapper needed) |
| PTY kill | signal escalation via libc + pgrep walk | `taskkill /T /F` (atomic tree kill) |
| Fonts | CoreText (moved verbatim to `fonts/macos.rs`) | new `fontdb` backend (`fonts/windows.rs`), same wire contract |
| Ports panel | lsof + ps | netstat + sysinfo |
| Reveal / open URL | `open` | `explorer` / `rundll32` |
| Default shell | `$SHELL` → zsh | pwsh → powershell → `%COMSPEC%` |
| CLI detection | `which` binary | `which` crate (PATHEXT-aware, finds `claude.cmd` etc.) |
| Editor launch | `open -a <App>` | CLI shims (`code`, `cursor`, `zed`, `subl`) |
| Claude usage credentials | Keychain | `~/.claude/.credentials.json` |
| pi API keys | Keychain + `!security` reference | direct entry in `~/.pi/agent/auth.json` |
| Menu | native menu (unchanged) | no native menu; frontend Ctrl+Shift shortcuts |

Cross-cutting correctness work:
- `dunce::canonicalize` wherever repo identity is derived, so `\?\`-prefixed paths never leak into config/watcher/UI and all path spellings agree (registration, worktree list, watcher roots, usage aliases)
- `CREATE_NO_WINDOW` on every subprocess (git status polling would otherwise strobe console windows)
- `NUL` vs `/dev/null` for untracked diffs; Windows reserved device names guarded in worktree slugs; native-path splitting for usage project labels; Claude Code's Windows label encoding (`C--Users-...`) handled in alias resolution
- New `prepare_for_update` command: on Windows the updater launches the installer and terminates the process (bypassing the quit guard), so sessions are confirmed and reaped first

## Frontend

- Frameless window with custom caption buttons (min/max/close) on Windows; drag region and quit-guard flow preserved
- Window-level Ctrl+Shift shortcuts replace the native menu accelerators (documented in README); plain Ctrl+letter chords still reach the terminal
- xterm `windowsPty: conpty` so reflow/copy behave under ConPTY; Ctrl+Shift+C/V copy-paste per Windows terminal convention
- Acrylic/Blur effects for the Glass themes (HudWindow is macOS-only); platform-aware fonts, labels, and keybinding presets
- Updater uses download-then-install on Windows with an active-session confirmation

## Build / release

- `Cargo.toml`: core-text/core-foundation gated to macOS, libc to unix; fontdb/sysinfo/which added under Windows targets
- `tauri.windows.conf.json` (platform config merge): frameless + transparent window, NSIS per-user install, passive updater install mode
- `generate-update-json.sh` now emits and **merges** platform entries so mac + Windows lanes share one `latest.json` (previously a Windows build would have clobbered the darwin entry); new `scripts/release-build.ps1` is the Windows release lane; `docs/RELEASING.md` (previously referenced by scripts but missing) documents the two-lane flow
- README: Windows install/build requirements, artifact paths, shortcut table

## Notes for review

- The Windows keyboard chords use Ctrl+Shift (T/A/M/G/B/E) rather than plain Ctrl because Ctrl+letter is a terminal control character — happy to adjust if you prefer different bindings.
- Unsigned Windows builds trigger SmartScreen; Authenticode config (`bundle.windows`) is left for when a cert is available. The updater minisign key signs both platforms as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)