### PR TITLE
Agent skills: registry, orchestrate skill, and sidebar install menu

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3971,7 +3971,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shep"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "core-foundation",
  "core-text",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,6 +13,7 @@ use crate::git;
 use crate::git::{ChangedFile, CreatedWorktree, DiffFileStat, GitStatus, WorktreeEntry};
 use crate::pty::manager::PtyManager;
 use crate::pty::session::{PtyColorTheme, PtyOutput};
+use crate::skills;
 use crate::todos::{self, TodoFile};
 use crate::usage::{
     LocalUsageDetails, ProviderUsageSnapshot, UsageDb, UsageOverview, UsageProjectAliasReviewItem,
@@ -496,13 +497,18 @@ pub fn move_todo(
 }
 
 #[tauri::command]
-pub fn has_todo_skill(repo_path: &str) -> bool {
-    todos::has_todo_skill(repo_path)
+pub fn list_skills(repo_path: &str) -> Vec<skills::SkillInfo> {
+    skills::list_skills(repo_path)
 }
 
 #[tauri::command]
-pub fn setup_todo_skill(repo_path: &str) -> Result<(), String> {
-    todos::setup_todo_skill(repo_path)
+pub fn setup_skill(repo_path: &str, name: &str) -> Result<(), String> {
+    skills::setup_skill(repo_path, name)
+}
+
+#[tauri::command]
+pub fn remove_skill(repo_path: &str, name: &str) -> Result<(), String> {
+    skills::remove_skill(repo_path, name)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod git;
 mod menu;
 mod pi_config;
 mod pty;
+mod skills;
 mod todos;
 mod usage;
 mod watcher;
@@ -135,8 +136,9 @@ pub fn run() {
             commands::toggle_todo,
             commands::add_todo,
             commands::move_todo,
-            commands::has_todo_skill,
-            commands::setup_todo_skill,
+            commands::list_skills,
+            commands::setup_skill,
+            commands::remove_skill,
             commands::check_command_exists,
             commands::get_usage_settings,
             commands::save_usage_settings,

--- a/src-tauri/src/orchestrate_skill.md
+++ b/src-tauri/src/orchestrate_skill.md
@@ -1,0 +1,164 @@
+---
+name: orchestrate
+description: Drive a feature end-to-end as planner/orchestrator while delegating implementation to a different agent CLI running headless, then finish with a fresh-context audit. Use ONLY when the user explicitly asks — /orchestrate, "drive another agent/model", "delegate this to <tool>", "run a plan-worker-audit workflow". Never self-select this skill just because a task is large; if orchestration seems like a good fit, suggest it and let the user decide.
+---
+
+# Orchestrate: plan → delegate → review → audit
+
+You — whichever agent loaded this skill — are the planner, orchestrator,
+and reviewer. A **worker** (another agent CLI run headless) writes the
+code. A fresh-context audit checks the result. You own the plan, all git
+operations, and the final verdict — the worker only edits files.
+
+## Role assignment — settle it up front, once
+
+Detect the available CLIs (`which codex claude gemini opencode pi agy`).
+Then, unless the user already named tools or models, ask **one compact
+question** before planning: proposed worker and proposed auditor, with
+your recommendation stated and alternatives listed. Recommend a worker
+from a **different model family than your own**, and an auditor from a
+third family when one is available — cross-model review catches
+uncorrelated blind spots. Don't re-ask per phase or per task; the
+assignment holds for the whole run.
+
+## Tool reference
+
+Flags verified against installed versions; they drift between releases —
+on failure, check the tool's `--help` once, adapt, then fall back to the
+next choice.
+
+| CLI | Headless dispatch | Feedback / resume | Model selection |
+|---|---|---|---|
+| codex | `codex exec -s workspace-write -C <root> -o <result-file> - < spec.md` | `codex exec resume --last "<feedback>"` | `-m <id>` |
+| claude | `claude -p "$(cat spec.md)" --permission-mode acceptEdits` | `claude -p --continue "<feedback>"` | `--model sonnet\|opus\|haiku` or full id |
+| gemini | `gemini -p "$(cat spec.md)" --approval-mode auto_edit` | `gemini -p --resume latest "<feedback>"` | `-m gemini-3-pro-preview`, `-m gemini-3-flash-preview`; omit for Auto (recommended) |
+| pi | `pi -p "$(cat spec.md)"` | `pi -p -c "<feedback>"` | `--model <pattern>` (fuzzy, `provider/id:<thinking>`); discover: `pi --list-models [search]` |
+| agy | `agy -p "$(cat spec.md)" --print-timeout 30m` | `agy -p -c "<feedback>"` | `--model "<display name>"`; discover: `agy models` |
+| opencode | `opencode run "$(cat spec.md)"` | `opencode run -c "<feedback>"` | `-m provider/model`; discover: `opencode models` |
+
+Per-tool caveats:
+
+- **agy** needs the Antigravity app running, and its print mode defaults
+  to a 5-minute timeout — always set `--print-timeout` generously. Its
+  permission bypass flag is `--dangerously-skip-permissions`; use it only
+  if the user has okayed that mode.
+- **pi** executes tools directly (no approval layer) and bills provider
+  API keys per token rather than a subscription — say so when proposing it.
+- **codex / claude / gemini / agy** ride the user's existing
+  subscriptions; prefer them when cost matters.
+- `gemini -p` and `codex exec` both accept the spec on stdin, which
+  avoids shell-quoting issues with large specs.
+
+## Model selection
+
+- **Default to each CLI's own default model** — it's what the vendor
+  tuned the tool for and what the subscription covers. Pin a model only
+  when the user asks or the task clearly warrants it (e.g. a cheap/fast
+  model for mechanical edits, a frontier model for gnarly refactors).
+- When the user wants options, discover them with `pi --list-models`,
+  `agy models`, or `opencode models` and present a short list — don't
+  dump full catalogs.
+- **Fallback rule:** if a pinned model errors or isn't available, retry
+  once on the CLI's default model, and record the substitution in the
+  final report. If the CLI itself fails twice, move to the next available
+  CLI (tell the user in the report, or immediately if they pinned it).
+
+## Decisions still belong to the user
+
+You own execution; the user owns product and scope. Keep asks rare,
+compact, and batched — a run should need at most a couple:
+
+- **Planning:** if requirements genuinely fork (two defensible designs,
+  unclear scope boundary), ask one batched question before dispatching.
+  Don't ask about things the codebase or conventions already answer.
+- **Mid-run:** reversible and in-scope → proceed. Scope-changing,
+  destructive, or outward-facing (pushes, publishes, deletions) → stop
+  and ask.
+- **Review/audit:** findings that imply a scope decision (e.g. "fixing
+  this properly means changing the API") go to the user — in the report
+  if the run can complete without it, as a question if it blocks.
+
+## Working directory
+
+Keep orchestration artifacts in `.orchestrate/<task-slug>/` at the repo
+root: `plan.md`, one spec per task (`task-1.md`, …), and worker output
+(`task-1.result.md`, …). Never commit this directory; add it to
+`.gitignore` if the repo has one and it isn't listed.
+
+## Phase 1 — Plan
+
+1. Explore the codebase enough to plan concretely (files, patterns,
+   constraints). Do this yourself — planning is your job, not the worker's.
+2. Write `plan.md`: the goal, approach, role assignment (worker, auditor,
+   models), and an ordered list of worker tasks. Prefer few, meaty tasks
+   over many tiny ones; each roundtrip to the worker has overhead.
+3. Write one spec file per task. **Specs must be fully self-contained** —
+   the worker sees nothing but the spec and the repo. Each spec includes:
+   - Goal (one paragraph) and any repo conventions that apply
+   - Exact files to touch (and files NOT to touch)
+   - Acceptance criteria as a checklist
+   - A verify command (test/build/lint) the work must pass
+   - The line: "Do not commit. Do not create branches. Leave changes in
+     the working tree."
+
+## Phase 2 — Dispatch
+
+Run the worker in a background shell, one task at a time. Sequential is
+the default — "continue/resume last session" feedback targets the most
+recent session, so parallel workers make feedback ambiguous. Run tasks
+in parallel only when they are truly independent AND each gets its own
+git worktree; otherwise don't.
+
+## Phase 3 — Review each task
+
+When the worker finishes:
+
+1. Read its result summary and `git diff`.
+2. Check the diff against the spec's acceptance criteria, and check that
+   it matches repo conventions (the repo's agent instructions apply to
+   the worker's code too — you enforce them).
+3. Run the verify command yourself. Do not trust the worker's claim that
+   it passed.
+4. Verdict:
+   - **Pass** → next task.
+   - **Small issues** (naming, a missed edge case, style) → fix them
+     yourself; cheaper than a roundtrip.
+   - **Substantive miss** → resume the worker's session with feedback
+     (see table above). Maximum 2 feedback rounds per task; after that,
+     take the task over and implement it yourself. Note the takeover in
+     `plan.md`.
+
+## Phase 4 — Fresh-context audit
+
+After all tasks pass, get a review from a context that did NOT watch the
+work happen — the assigned auditor, run headless and read-only where the
+tool supports it (`codex exec -s read-only` or `codex exec review`;
+`gemini -p --approval-mode plan`; otherwise a plain `-p` run told to only
+read). Give it the goal, the full diff, and the prompt: "Review this
+change for bugs, missed requirements, and convention violations."
+
+Triage the findings yourself: fix confirmed real issues (route back
+through Phase 2/3 if substantial), explicitly dismiss false positives
+with a reason, and escalate scope-level findings to the user per the
+decisions section.
+
+## Phase 5 — Report
+
+Tell the user, in this order: what was built and whether verification
+passed (with the actual command output as evidence), what the worker did
+vs. what you did or took over, audit findings and how each was resolved,
+any model/CLI substitutions that happened, and anything left open. If
+the project has a `TODO.md` board (shep-todos), update it to reflect the
+finished work.
+
+## Rules
+
+- You own git. The worker never commits, branches, or pushes. You only
+  commit if the user asked for commits.
+- Never paste large code bodies into specs — reference file paths; the
+  worker can read the repo.
+- If a worker errors twice on dispatch (auth, flags), stop retrying:
+  adapt once from `--help`, then fall back per the model-selection rules
+  and tell the user why.
+- The user's approval covers the plan's scope. New scope discovered
+  mid-flight goes in the report, not into extra worker tasks.

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -1,0 +1,241 @@
+use std::fs;
+use std::path::Path;
+
+/// A prebuilt agent skill Shep can install into a repo. The markdown is
+/// embedded at compile time; `name` doubles as the directory name under
+/// `.agents/skills/` and must match the frontmatter `name:` in the file.
+struct BuiltinSkill {
+    name: &'static str,
+    title: &'static str,
+    description: &'static str,
+    markdown: &'static str,
+}
+
+const BUILTIN_SKILLS: &[BuiltinSkill] = &[
+    BuiltinSkill {
+        name: "shep-todos",
+        title: "Project to-dos",
+        description: "Teaches agents to keep TODO.md as a kanban board: move cards when starting or finishing work, add discovered work to the backlog, and reconcile the board before ending a session.",
+        markdown: include_str!("todo_skill.md"),
+    },
+    BuiltinSkill {
+        name: "orchestrate",
+        title: "Orchestrate",
+        description: "Turns any agent into a planner/orchestrator that delegates implementation to a different agent CLI running headless (codex, claude, opencode), reviews each task, and finishes with a fresh-context audit.",
+        markdown: include_str!("orchestrate_skill.md"),
+    },
+];
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillInfo {
+    pub name: String,
+    pub title: String,
+    pub description: String,
+    pub installed: bool,
+}
+
+fn find_skill(name: &str) -> Result<&'static BuiltinSkill, String> {
+    BUILTIN_SKILLS
+        .iter()
+        .find(|s| s.name == name)
+        .ok_or_else(|| format!("Unknown skill: {name}"))
+}
+
+/// Whether the repo has the named skill installed at the standard location.
+pub fn has_skill(repo_path: &str, name: &str) -> bool {
+    Path::new(repo_path)
+        .join(".agents/skills")
+        .join(name)
+        .join("SKILL.md")
+        .is_file()
+}
+
+/// All built-in skills with their install state for this repo.
+pub fn list_skills(repo_path: &str) -> Vec<SkillInfo> {
+    BUILTIN_SKILLS
+        .iter()
+        .map(|s| SkillInfo {
+            name: s.name.to_string(),
+            title: s.title.to_string(),
+            description: s.description.to_string(),
+            installed: has_skill(repo_path, s.name),
+        })
+        .collect()
+}
+
+/// Write the skill at the cross-agent standard location (`.agents/skills/`)
+/// and point `.claude/skills/` at it so Claude Code, Codex, and OpenCode
+/// all pick it up from a single source file.
+pub fn setup_skill(repo_path: &str, name: &str) -> Result<(), String> {
+    let skill = find_skill(name)?;
+    let root = Path::new(repo_path);
+    if !root.is_dir() {
+        return Err(format!("Not a directory: {repo_path}"));
+    }
+
+    let skill_dir = root.join(".agents/skills").join(skill.name);
+    fs::create_dir_all(&skill_dir)
+        .map_err(|e| format!("Failed to create {}: {e}", skill_dir.display()))?;
+    fs::write(skill_dir.join("SKILL.md"), skill.markdown)
+        .map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
+
+    let claude_skills = root.join(".claude/skills");
+    let pointer = claude_skills.join(skill.name);
+    if pointer.symlink_metadata().is_ok() {
+        return Ok(()); // Something already there — leave the user's setup alone.
+    }
+    fs::create_dir_all(&claude_skills)
+        .map_err(|e| format!("Failed to create {}: {e}", claude_skills.display()))?;
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(
+        Path::new("../../.agents/skills").join(skill.name),
+        &pointer,
+    )
+    .map_err(|e| format!("Failed to link Claude skill: {e}"))?;
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(&pointer).map_err(|e| format!("Failed to create skill dir: {e}"))?;
+        fs::write(pointer.join("SKILL.md"), skill.markdown)
+            .map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Remove an installed skill: the `.agents/skills/<name>` directory, plus
+/// the `.claude/skills/<name>` pointer — but only if the pointer is ours
+/// (a symlink, or on non-unix a directory holding just SKILL.md).
+pub fn remove_skill(repo_path: &str, name: &str) -> Result<(), String> {
+    find_skill(name)?;
+    let root = Path::new(repo_path);
+
+    let skill_dir = root.join(".agents/skills").join(name);
+    if skill_dir.is_dir() {
+        fs::remove_dir_all(&skill_dir)
+            .map_err(|e| format!("Failed to remove {}: {e}", skill_dir.display()))?;
+    }
+
+    let pointer = root.join(".claude/skills").join(name);
+    if let Ok(meta) = pointer.symlink_metadata() {
+        if meta.file_type().is_symlink() {
+            fs::remove_file(&pointer)
+                .map_err(|e| format!("Failed to remove {}: {e}", pointer.display()))?;
+        } else if meta.is_dir() {
+            let only_skill_md = fs::read_dir(&pointer)
+                .map(|entries| {
+                    entries
+                        .flatten()
+                        .all(|e| e.file_name().to_string_lossy() == "SKILL.md")
+                })
+                .unwrap_or(false);
+            if only_skill_md {
+                fs::remove_dir_all(&pointer)
+                    .map_err(|e| format!("Failed to remove {}: {e}", pointer.display()))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_repo(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("shep-skills-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn registry_markdown_names_match_directories() {
+        for skill in BUILTIN_SKILLS {
+            assert!(
+                skill.markdown.contains(&format!("name: {}", skill.name)),
+                "frontmatter name mismatch for {}",
+                skill.name
+            );
+        }
+    }
+
+    #[test]
+    fn setup_writes_standard_location_and_claude_pointer() {
+        let dir = temp_repo("setup");
+        let repo = dir.to_string_lossy().to_string();
+
+        assert!(!has_skill(&repo, "shep-todos"));
+        setup_skill(&repo, "shep-todos").unwrap();
+        assert!(has_skill(&repo, "shep-todos"));
+
+        let real = dir.join(".agents/skills/shep-todos/SKILL.md");
+        assert!(real.is_file());
+        assert!(fs::read_to_string(&real).unwrap().contains("name: shep-todos"));
+
+        // The Claude pointer resolves to the same skill.
+        let pointer = dir.join(".claude/skills/shep-todos/SKILL.md");
+        assert!(fs::read_to_string(&pointer).unwrap().contains("name: shep-todos"));
+
+        // Idempotent — a second run doesn't fail on the existing pointer.
+        setup_skill(&repo, "shep-todos").unwrap();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn list_reflects_install_state() {
+        let dir = temp_repo("list");
+        let repo = dir.to_string_lossy().to_string();
+
+        let before = list_skills(&repo);
+        assert_eq!(before.len(), BUILTIN_SKILLS.len());
+        assert!(before.iter().all(|s| !s.installed));
+
+        setup_skill(&repo, "orchestrate").unwrap();
+        let after = list_skills(&repo);
+        assert!(after.iter().find(|s| s.name == "orchestrate").unwrap().installed);
+        assert!(!after.iter().find(|s| s.name == "shep-todos").unwrap().installed);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_deletes_skill_and_our_pointer() {
+        let dir = temp_repo("remove");
+        let repo = dir.to_string_lossy().to_string();
+
+        setup_skill(&repo, "orchestrate").unwrap();
+        remove_skill(&repo, "orchestrate").unwrap();
+        assert!(!has_skill(&repo, "orchestrate"));
+        assert!(dir.join(".claude/skills/orchestrate").symlink_metadata().is_err());
+
+        // Removing an absent skill is a no-op, not an error.
+        remove_skill(&repo, "orchestrate").unwrap();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_leaves_foreign_claude_dir_alone() {
+        let dir = temp_repo("foreign");
+        let repo = dir.to_string_lossy().to_string();
+
+        // A user-authored real directory at the pointer path, with extra files.
+        let foreign = dir.join(".claude/skills/orchestrate");
+        fs::create_dir_all(&foreign).unwrap();
+        fs::write(foreign.join("SKILL.md"), "user's own\n").unwrap();
+        fs::write(foreign.join("notes.md"), "keep me\n").unwrap();
+
+        remove_skill(&repo, "orchestrate").unwrap();
+        assert!(foreign.join("notes.md").is_file());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unknown_skill_is_an_error() {
+        let dir = temp_repo("unknown");
+        let repo = dir.to_string_lossy().to_string();
+        assert!(setup_skill(&repo, "nope").is_err());
+        assert!(remove_skill(&repo, "nope").is_err());
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -25,11 +25,6 @@ const MAX_TODO_FILES: usize = 20;
 /// Skip parsing files larger than this — a real todo list is never 1 MB.
 const MAX_FILE_BYTES: u64 = 1024 * 1024;
 
-/// Skill directory name written by `setup_todo_skill`.
-const SKILL_NAME: &str = "shep-todos";
-
-const SKILL_MD: &str = include_str!("todo_skill.md");
-
 #[derive(serde::Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TodoItem {
@@ -273,54 +268,6 @@ pub fn add_todo(
         joined.push('\n');
     }
     fs::write(&path, joined).map_err(|e| format!("Failed to write {}: {e}", path.display()))
-}
-
-// ── Agent skill ──────────────────────────────────────────────────────
-
-/// Whether the repo already has the shep-todos agent skill installed.
-pub fn has_todo_skill(repo_path: &str) -> bool {
-    Path::new(repo_path)
-        .join(".agents/skills")
-        .join(SKILL_NAME)
-        .join("SKILL.md")
-        .is_file()
-}
-
-/// Write the shep-todos skill at the cross-agent standard location
-/// (`.agents/skills/`) and point `.claude/skills/` at it so Claude Code,
-/// Codex, and OpenCode all pick it up from a single source file.
-pub fn setup_todo_skill(repo_path: &str) -> Result<(), String> {
-    let root = Path::new(repo_path);
-    if !root.is_dir() {
-        return Err(format!("Not a directory: {repo_path}"));
-    }
-
-    let skill_dir = root.join(".agents/skills").join(SKILL_NAME);
-    fs::create_dir_all(&skill_dir)
-        .map_err(|e| format!("Failed to create {}: {e}", skill_dir.display()))?;
-    fs::write(skill_dir.join("SKILL.md"), SKILL_MD)
-        .map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
-
-    let claude_skills = root.join(".claude/skills");
-    let pointer = claude_skills.join(SKILL_NAME);
-    if pointer.symlink_metadata().is_ok() {
-        return Ok(()); // Something already there — leave the user's setup alone.
-    }
-    fs::create_dir_all(&claude_skills)
-        .map_err(|e| format!("Failed to create {}: {e}", claude_skills.display()))?;
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(
-        Path::new("../../.agents/skills").join(SKILL_NAME),
-        &pointer,
-    )
-    .map_err(|e| format!("Failed to link Claude skill: {e}"))?;
-    #[cfg(not(unix))]
-    {
-        fs::create_dir_all(&pointer).map_err(|e| format!("Failed to create skill dir: {e}"))?;
-        fs::write(pointer.join("SKILL.md"), SKILL_MD)
-            .map_err(|e| format!("Failed to write SKILL.md: {e}"))?;
-    }
-    Ok(())
 }
 
 // ── Parsing ──────────────────────────────────────────────────────────
@@ -701,26 +648,5 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    #[test]
-    fn skill_setup_writes_standard_location_and_claude_pointer() {
-        let dir = temp_repo("skill");
-        let repo = dir.to_string_lossy().to_string();
-
-        assert!(!has_todo_skill(&repo));
-        setup_todo_skill(&repo).unwrap();
-        assert!(has_todo_skill(&repo));
-
-        let real = dir.join(".agents/skills/shep-todos/SKILL.md");
-        assert!(real.is_file());
-        assert!(fs::read_to_string(&real).unwrap().contains("name: shep-todos"));
-
-        // The Claude pointer resolves to the same skill.
-        let pointer = dir.join(".claude/skills/shep-todos/SKILL.md");
-        assert!(fs::read_to_string(&pointer).unwrap().contains("name: shep-todos"));
-
-        // Idempotent — a second run doesn't fail on the existing pointer.
-        setup_todo_skill(&repo).unwrap();
-        let _ = fs::remove_dir_all(&dir);
-    }
 }
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -10,6 +10,8 @@ import { useRepoStore } from "../../stores/useRepoStore";
 import { useCommandStore } from "../../stores/useCommandStore";
 import { useTerminalStore } from "../../stores/useTerminalStore";
 import { useGitStore } from "../../stores/useGitStore";
+import { useTodoStore } from "../../stores/useTodoStore";
+import { useSkillStore } from "../../stores/useSkillStore";
 import { useUIStore } from "../../stores/useUIStore";
 import { useShallow } from "zustand/shallow";
 import { usePty } from "../../hooks/usePty";
@@ -292,6 +294,8 @@ export default function AppShell() {
         useTerminalStore.getState().removeProject(repoPath);
         useCommandStore.getState().removeProject(repoPath);
         useGitStore.getState().removeProject(repoPath);
+        useTodoStore.getState().removeProject(repoPath);
+        useSkillStore.getState().removeProject(repoPath);
       } catch (error) {
         pushNotice({
           tone: "error",

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -184,6 +184,7 @@ export default function SettingsPanel() {
     };
   }, [fontPickerOpen]);
 
+
   // Assemble the searchable list: always surface the bundled MesloLGS NF
   // (the default) even if CoreText didn't return it as a system-installed
   // family, then append everything from Rust. Dedupe by family name.

--- a/src/components/sidebar/ProjectItem.tsx
+++ b/src/components/sidebar/ProjectItem.tsx
@@ -11,15 +11,20 @@ import {
   Copy,
   Trash2,
   SquareArrowOutUpRight,
+  Sparkles,
+  Check,
 } from "lucide-react";
 import { createPortal } from "react-dom";
 import ContextMenu from "../shared/ContextMenu";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useSkillStore } from "../../stores/useSkillStore";
 import { getErrorMessage } from "../../lib/errors";
 import { handleActionKey } from "../../lib/a11y";
 import { gitCreateWorktree, revealInFinder } from "../../lib/tauri";
 import ActivityIndicator, { getAggregateActivityStatus } from "./ActivityIndicator";
+
+const EMPTY_SKILLS: never[] = [];
 
 interface ProjectItemProps {
   repo: RepoInfo;
@@ -57,6 +62,7 @@ export default function ProjectItem({
     hasRunning: Boolean(activity && (activity.terminalCount > 0 || activity.runningCount > 0)),
   });
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const skills = useSkillStore((s) => s.skillsByRepo[repo.path] ?? EMPTY_SKILLS);
   const preferredEditor = useEditorStore((s) => s.settings.preferredEditor);
   const pushNotice = useNoticeStore((s) => s.pushNotice);
   const preferredEditorLabel = getEditorLabel(preferredEditor);
@@ -94,7 +100,9 @@ export default function ProjectItem({
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     setMenu({ x: e.clientX, y: e.clientY });
-  }, []);
+    // Skill state can change outside Shep (agents, git) — re-check on open.
+    void useSkillStore.getState().refresh(repo.path);
+  }, [repo.path]);
 
   const handleClose = useCallback(() => {
     setMenu(null);
@@ -162,6 +170,25 @@ export default function ProjectItem({
       : []),
   ];
 
+  const skillChildren: ContextMenuItem[] = skills.map((skill) => ({
+    label: skill.title,
+    icon: <Check size={14} className={skill.installed ? "opacity-100" : "opacity-0"} />,
+    keepOpen: true,
+    onClick: () => {
+      const store = useSkillStore.getState();
+      const action = skill.installed
+        ? store.uninstall(repo.path, skill.name)
+        : store.install(repo.path, skill.name);
+      void action.catch((error) => {
+        pushNotice({
+          tone: "error",
+          title: skill.installed ? "Couldn't remove agent skill" : "Couldn't add agent skill",
+          message: getErrorMessage(error),
+        });
+      });
+    },
+  }));
+
   const menuItems: ContextMenuItem[] = [
     {
       label: editorActionLabel,
@@ -208,6 +235,15 @@ export default function ProjectItem({
       icon: <FolderInput size={14} />,
       children: moveToChildren,
     },
+    ...(skillChildren.length > 0
+      ? [
+          {
+            label: "Agent Skills",
+            icon: <Sparkles size={14} />,
+            children: skillChildren,
+          },
+        ]
+      : []),
     {
       label: "Create Worktree",
       icon: <Plus size={14} />,

--- a/src/components/todos/TodosPanel.tsx
+++ b/src/components/todos/TodosPanel.tsx
@@ -5,6 +5,7 @@ import type { TodoFile, TodoItem, TodoSection } from "../../lib/types";
 import { renderInlineMarkdown } from "../../lib/inlineMarkdown";
 import { useTerminalStore } from "../../stores/useTerminalStore";
 import { useTodoStore } from "../../stores/useTodoStore";
+import { useSkillStore } from "../../stores/useSkillStore";
 import { useProjectSettingsStore } from "../../stores/useProjectSettingsStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 import { getErrorMessage } from "../../lib/errors";
@@ -236,9 +237,11 @@ export default function TodosPanel() {
     activeProjectPath ? s.projectTodos[activeProjectPath] : undefined,
   );
   // Unknown (not yet checked) counts as present so the button doesn't flash.
-  const skillPresent = useTodoStore((s) =>
-    activeProjectPath ? (s.skillPresent[activeProjectPath] ?? true) : true,
-  );
+  const skillPresent = useSkillStore((s) => {
+    if (!activeProjectPath) return true;
+    const skills = s.skillsByRepo[activeProjectPath];
+    return skills ? skills.some((sk) => sk.name === "shep-todos" && sk.installed) : true;
+  });
   const todoFileStyle = useProjectSettingsStore((s) => s.settings.todoFileStyle);
   const pushNotice = useNoticeStore((s) => s.pushNotice);
   const [draft, setDraft] = useState("");
@@ -336,7 +339,7 @@ export default function TodosPanel() {
     if (installingSkill) return;
     setInstallingSkill(true);
     try {
-      await useTodoStore.getState().installSkill(activeProjectPath);
+      await useSkillStore.getState().install(activeProjectPath, "shep-todos");
       pushNotice({
         tone: "info",
         title: "Agent skill added",

--- a/src/hooks/useGitWatcher.ts
+++ b/src/hooks/useGitWatcher.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { watchRepo, unwatchRepo } from "../lib/tauri";
 import { useGitStore } from "../stores/useGitStore";
 import { useTodoStore } from "../stores/useTodoStore";
+import { useSkillStore } from "../stores/useSkillStore";
 import { useProjectSettingsStore } from "../stores/useProjectSettingsStore";
 
 interface FsChangedPayload {
@@ -19,6 +20,7 @@ export function useGitWatcher(repoPaths: string[]) {
   useEffect(() => {
     const unlisten = listen<FsChangedPayload>("git-fs-changed", (event) => {
       void useGitStore.getState().refreshAll(event.payload.paths);
+      void useSkillStore.getState().refreshAll(event.payload.paths);
       if (useProjectSettingsStore.getState().settings.showTodos) {
         void useTodoStore.getState().refreshAll(event.payload.paths);
       }
@@ -54,6 +56,7 @@ export function useGitWatcher(repoPaths: string[]) {
 
     // Initial refresh
     void refreshAll(repoPaths);
+    void useSkillStore.getState().refreshAll(repoPaths);
     if (useProjectSettingsStore.getState().settings.showTodos) {
       void useTodoStore.getState().refreshAll(repoPaths);
     }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -27,6 +27,7 @@ import type {
   PiSettings,
   DiffFileStat,
   TodoFile,
+  SkillInfo,
 } from "./types";
 
 // ── Workspace commands ──────────────────────────────────────────────
@@ -249,12 +250,16 @@ export function moveTodo(
   return invoke("move_todo", { filePath, line, expectedText, targetSectionLine, setChecked });
 }
 
-export function hasTodoSkill(repoPath: string): Promise<boolean> {
-  return invoke("has_todo_skill", { repoPath });
+export function listSkills(repoPath: string): Promise<SkillInfo[]> {
+  return invoke("list_skills", { repoPath });
 }
 
-export function setupTodoSkill(repoPath: string): Promise<void> {
-  return invoke("setup_todo_skill", { repoPath });
+export function setupSkill(repoPath: string, name: string): Promise<void> {
+  return invoke("setup_skill", { repoPath, name });
+}
+
+export function removeSkill(repoPath: string, name: string): Promise<void> {
+  return invoke("remove_skill", { repoPath, name });
 }
 
 export function gitListWorktrees(path: string): Promise<WorktreeEntry[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -217,6 +217,15 @@ export interface TodoFile {
   items: TodoItem[];
 }
 
+// ── Agent skills ─────────────────────────────────────────────────────
+
+export interface SkillInfo {
+  name: string;
+  title: string;
+  description: string;
+  installed: boolean;
+}
+
 // ── Git diff stats ───────────────────────────────────────────────────
 
 export interface DiffFileStat {

--- a/src/stores/useSkillStore.ts
+++ b/src/stores/useSkillStore.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import type { SkillInfo } from "../lib/types";
+import { listSkills, setupSkill, removeSkill } from "../lib/tauri";
+
+interface SkillStore {
+  /** Built-in agent skills with install state, per repo. The files on disk
+   *  (.agents/skills/) are the source of truth — this is only a render cache. */
+  skillsByRepo: Record<string, SkillInfo[]>;
+  refresh: (repoPath: string) => Promise<void>;
+  refreshAll: (repoPaths: string[]) => Promise<void>;
+  install: (repoPath: string, name: string) => Promise<void>;
+  uninstall: (repoPath: string, name: string) => Promise<void>;
+  removeProject: (repoPath: string) => void;
+}
+
+function skillsEqual(a: SkillInfo[] | undefined, b: SkillInfo[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].name !== b[i].name || a[i].installed !== b[i].installed) return false;
+  }
+  return true;
+}
+
+export const useSkillStore = create<SkillStore>((set, get) => ({
+  skillsByRepo: {},
+
+  refresh: async (repoPath) => {
+    try {
+      const skills = await listSkills(repoPath);
+      set((state) =>
+        skillsEqual(state.skillsByRepo[repoPath], skills)
+          ? state
+          : { skillsByRepo: { ...state.skillsByRepo, [repoPath]: skills } },
+      );
+    } catch {
+      // Repo may have been removed from disk — leave the cache untouched
+    }
+  },
+
+  refreshAll: async (repoPaths) => {
+    const results = await Promise.allSettled(repoPaths.map((p) => listSkills(p)));
+    set((state) => {
+      let changed = false;
+      const next = { ...state.skillsByRepo };
+      for (let i = 0; i < repoPaths.length; i++) {
+        const result = results[i];
+        if (result.status === "fulfilled" && !skillsEqual(state.skillsByRepo[repoPaths[i]], result.value)) {
+          next[repoPaths[i]] = result.value;
+          changed = true;
+        }
+      }
+      return changed ? { skillsByRepo: next } : state;
+    });
+  },
+
+  install: async (repoPath, name) => {
+    await setupSkill(repoPath, name);
+    await get().refresh(repoPath);
+  },
+
+  uninstall: async (repoPath, name) => {
+    await removeSkill(repoPath, name);
+    await get().refresh(repoPath);
+  },
+
+  removeProject: (repoPath) => {
+    set((state) => {
+      const { [repoPath]: _, ...rest } = state.skillsByRepo;
+      return { skillsByRepo: rest };
+    });
+  },
+}));

--- a/src/stores/useTodoStore.ts
+++ b/src/stores/useTodoStore.ts
@@ -1,20 +1,11 @@
 import { create } from "zustand";
 import type { TodoFile } from "../lib/types";
-import {
-  readTodos,
-  toggleTodo,
-  addTodo,
-  moveTodo,
-  hasTodoSkill,
-  setupTodoSkill,
-} from "../lib/tauri";
+import { readTodos, toggleTodo, addTodo, moveTodo } from "../lib/tauri";
 
 interface TodoStore {
   /** TODO.md files per repo. The file on disk is the source of truth — this
    *  is only a render cache, refreshed from fs events and after every write. */
   projectTodos: Record<string, TodoFile[]>;
-  /** Whether the repo has the shep-todos agent skill installed. */
-  skillPresent: Record<string, boolean>;
   refreshTodos: (repoPath: string) => Promise<void>;
   refreshAll: (repoPaths: string[]) => Promise<void>;
   toggleItem: (
@@ -39,7 +30,6 @@ interface TodoStore {
     targetSectionLine: number,
     setChecked: boolean | null,
   ) => Promise<void>;
-  installSkill: (repoPath: string) => Promise<void>;
   removeProject: (repoPath: string) => void;
 }
 
@@ -65,24 +55,15 @@ function todoFilesEqual(a: TodoFile[] | undefined, b: TodoFile[]): boolean {
 
 export const useTodoStore = create<TodoStore>((set, get) => ({
   projectTodos: {},
-  skillPresent: {},
 
   refreshTodos: async (repoPath: string) => {
     try {
-      const [files, skill] = await Promise.all([readTodos(repoPath), hasTodoSkill(repoPath)]);
-      set((state) => {
-        const filesChanged = !todoFilesEqual(state.projectTodos[repoPath], files);
-        const skillChanged = state.skillPresent[repoPath] !== skill;
-        if (!filesChanged && !skillChanged) return state;
-        return {
-          projectTodos: filesChanged
-            ? { ...state.projectTodos, [repoPath]: files }
-            : state.projectTodos,
-          skillPresent: skillChanged
-            ? { ...state.skillPresent, [repoPath]: skill }
-            : state.skillPresent,
-        };
-      });
+      const files = await readTodos(repoPath);
+      set((state) =>
+        todoFilesEqual(state.projectTodos[repoPath], files)
+          ? state
+          : { projectTodos: { ...state.projectTodos, [repoPath]: files } },
+      );
     } catch {
       // Repo may have been removed from disk — leave the cache untouched
     }
@@ -90,12 +71,10 @@ export const useTodoStore = create<TodoStore>((set, get) => ({
 
   refreshAll: async (repoPaths: string[]) => {
     const results = await Promise.allSettled(repoPaths.map((p) => readTodos(p)));
-    const skills = await Promise.allSettled(repoPaths.map((p) => hasTodoSkill(p)));
 
     set((state) => {
       let changed = false;
       const nextTodos = { ...state.projectTodos };
-      const nextSkills = { ...state.skillPresent };
 
       for (let i = 0; i < repoPaths.length; i++) {
         const result = results[i];
@@ -103,14 +82,9 @@ export const useTodoStore = create<TodoStore>((set, get) => ({
           nextTodos[repoPaths[i]] = result.value;
           changed = true;
         }
-        const skill = skills[i];
-        if (skill.status === "fulfilled" && state.skillPresent[repoPaths[i]] !== skill.value) {
-          nextSkills[repoPaths[i]] = skill.value;
-          changed = true;
-        }
       }
 
-      return changed ? { projectTodos: nextTodos, skillPresent: nextSkills } : state;
+      return changed ? { projectTodos: nextTodos } : state;
     });
   },
 
@@ -137,16 +111,10 @@ export const useTodoStore = create<TodoStore>((set, get) => ({
     }
   },
 
-  installSkill: async (repoPath) => {
-    await setupTodoSkill(repoPath);
-    set((state) => ({ skillPresent: { ...state.skillPresent, [repoPath]: true } }));
-  },
-
   removeProject: (repoPath: string) => {
     set((state) => {
       const { [repoPath]: _, ...rest } = state.projectTodos;
-      const { [repoPath]: __, ...restSkills } = state.skillPresent;
-      return { projectTodos: rest, skillPresent: restSkills };
+      return { projectTodos: rest };
     });
   },
 }));


### PR DESCRIPTION
## What

Generalizes the shep-todos skill install machinery into a **built-in agent skills registry** and adds a second skill: **Orchestrate**.

- **`src-tauri/src/skills.rs`** — registry of compile-time-embedded skills (`shep-todos` moved from `todos.rs` unchanged, plus the new `orchestrate`), with generic `list_skills` / `setup_skill` / `remove_skill` commands replacing the todo-specific pair. Install writes to the cross-agent `.agents/skills/` location with a `.claude/skills/` symlink, exactly as before. Removal only deletes pointers Shep created — user-authored directories at the pointer path are left alone.
- **Orchestrate skill** — model-agnostic plan → delegate → review → audit workflow: whichever agent loads it acts as planner/orchestrator and dispatches implementation to a *different* agent CLI running headless, then finishes with a fresh-context audit. Ships a tool table (dispatch/resume/model flags) verified against installed versions of codex, claude, gemini, pi, agy, and opencode, with model-fallback rules and explicit "decisions still go to the user" calibration. Trigger is explicit-only — the skill never self-selects on task size.
- **Sidebar install UX** — right-click a project → **Agent Skills** submenu; check mark = installed, click toggles, menu stays open for multiple toggles. Skill state re-checks from disk on menu open.
- **Frontend plumbing** — new `useSkillStore` (per-repo install-state cache, refreshed by the git watcher); `useTodoStore` no longer tracks skill state; project removal now also clears todo/skill caches (the todo half was previously dead code).

## Testing

- 6 new unit tests in `skills.rs` covering install/list/remove, idempotency, foreign-directory safety, and registry/frontmatter consistency; full suite passes (37).
- `tsc` and production `vite build` clean.
- Manually smoke-tested: install/remove from the context menu, skill pickup in a fresh agent session.

## Known limitation (accepted for this release)

Installed skills are snapshots — repos keep their installed copy until the skill is toggled off/on, even after Shep ships an updated version. Worth an auto-update pass in a future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDzZHgeBbqHEc2xurmkkN6