### PR TITLE
build: archive unsigned macOS builds locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .planning/
 latest.json
 .claude/settings.local.json
+builds/

--- a/README.md
+++ b/README.md
@@ -133,6 +133,37 @@ This starts the Vite frontend and the Tauri shell together.
 pnpm tauri build
 ```
 
+### Build an unsigned Apple Silicon app (Mac Studio)
+
+```bash
+pnpm tauri build --target aarch64-apple-darwin --bundles app,dmg --no-sign
+```
+
+This writes an installable DMG to:
+
+```text
+src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+```
+
+Open the DMG and drag `shep.app` to Applications when you are ready to replace
+an existing installation. It is intentionally unsigned, so macOS may require
+an explicit confirmation the first time it opens.
+
+### Archive local Mac Studio builds
+
+```bash
+pnpm build:local
+```
+
+This creates the unsigned Apple Silicon app and DMG, then copies both into an
+ignored `builds/<timestamp>-.../` directory together with `build.json`. The
+manifest records the source commit, whether the worktree was dirty, and
+SHA-256 checksums. To archive the current Tauri output without rebuilding:
+
+```bash
+pnpm build:local -- --archive-only
+```
+
 ### Create a debug-packaged build
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:local": "bash scripts/build-local.sh",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Build and archive a machine-local, unsigned macOS release bundle.
+set -euo pipefail
+
+usage() {
+  printf '%s\n' \
+    'usage: pnpm build:local [--archive-only]' \
+    '' \
+    'Builds an unsigned Apple Silicon app and DMG, then archives both under builds/.' \
+    '' \
+    'options:' \
+    '  --archive-only  Archive the current Tauri output without rebuilding.' \
+    '  -h, --help      Show this help.'
+}
+
+fail() {
+  printf 'error: %s\n' "$1"
+  exit "${2:-1}"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+if [ "${1:-}" = '--' ]; then
+  shift
+fi
+
+mode='build'
+case "$#" in
+  0) ;;
+  1) ;;
+  *)
+    printf 'error: expected at most one option\n'
+    usage
+    exit 2
+    ;;
+esac
+
+case "${1:-}" in
+  '') ;;
+  --archive-only) mode='archive-only' ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    printf 'error: unknown option: %s\n' "$1"
+    usage
+    exit 2
+    ;;
+esac
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+require_command git
+require_command jq
+require_command ditto
+require_command shasum
+if [ "$mode" = 'build' ]; then
+  require_command pnpm
+fi
+
+target='aarch64-apple-darwin'
+version="$(jq -er '.version | strings | select(length > 0)' package.json)" \
+  || fail 'could not read a non-empty version from package.json'
+bundle_root="src-tauri/target/${target}/release/bundle"
+app_source="${bundle_root}/macos/shep.app"
+dmg_name="shep_${version}_aarch64.dmg"
+dmg_source="${bundle_root}/dmg/${dmg_name}"
+
+if [ "$mode" = 'build' ]; then
+  printf 'build: pnpm tauri build --target %s --bundles app,dmg --no-sign\n' "$target" >&2
+  pnpm tauri build --target "$target" --bundles app,dmg --no-sign
+fi
+
+[ -d "$app_source" ] || fail "app artifact not found: $app_source"
+[ -f "$dmg_source" ] || fail "DMG artifact not found: $dmg_source"
+
+git_commit="$(git rev-parse HEAD)" || fail 'could not determine the current Git commit'
+git_short="${git_commit:0:12}"
+git_dirty=false
+if [ -n "$(git status --porcelain)" ]; then
+  git_dirty=true
+fi
+git_state='clean'
+if [ "$git_dirty" = true ]; then
+  git_state='dirty'
+fi
+
+timestamp="$(date '+%Y%m%d-%H%M%S')"
+archive_dir="${repo_root}/builds/${timestamp}-${target}-g${git_short}-${git_state}"
+if [ -e "$archive_dir" ]; then
+  fail "archive already exists: $archive_dir"
+fi
+
+mkdir -p "$archive_dir" || fail "could not create archive directory: $archive_dir"
+ditto "$app_source" "${archive_dir}/shep.app" \
+  || fail 'could not copy the app bundle into the archive'
+cp -p "$dmg_source" "${archive_dir}/${dmg_name}" \
+  || fail 'could not copy the DMG into the archive'
+
+app_sha256="$(shasum -a 256 "${archive_dir}/shep.app/Contents/MacOS/shep" | awk '{print $1}')" \
+  || fail 'could not checksum the archived app executable'
+dmg_sha256="$(shasum -a 256 "${archive_dir}/${dmg_name}" | awk '{print $1}')" \
+  || fail 'could not checksum the archived DMG'
+created_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+jq -n \
+  --arg created_at "$created_at" \
+  --arg mode "$mode" \
+  --arg version "$version" \
+  --arg target "$target" \
+  --arg git_commit "$git_commit" \
+  --argjson git_dirty "$git_dirty" \
+  --arg app_sha256 "$app_sha256" \
+  --arg dmg_name "$dmg_name" \
+  --arg dmg_sha256 "$dmg_sha256" \
+  '{
+    schema_version: 1,
+    created_at: $created_at,
+    archive_mode: $mode,
+    version: $version,
+    target: $target,
+    git_commit: $git_commit,
+    git_dirty: $git_dirty,
+    build_command: "pnpm tauri build --target aarch64-apple-darwin --bundles app,dmg --no-sign",
+    artifacts: {
+      app: { path: "shep.app", executable_sha256: $app_sha256 },
+      dmg: { path: $dmg_name, sha256: $dmg_sha256 }
+    }
+  }' > "${archive_dir}/build.json" \
+  || fail 'could not write the archive manifest'
+
+printf '%s\n' \
+  "archive: ${archive_dir}" \
+  "app: ${archive_dir}/shep.app" \
+  "dmg: ${archive_dir}/${dmg_name}" \
+  "manifest: ${archive_dir}/build.json" \
+  "git_commit: ${git_commit}" \
+  "git_dirty: ${git_dirty}"


### PR DESCRIPTION
## Summary

- add `pnpm build:local` for an unsigned Apple Silicon app and DMG build
- archive the finished `shep.app` and DMG under ignored `builds/<timestamp>-.../` directories
- write `build.json` with the source commit, dirty state, build command, and SHA-256 checksums
- support `pnpm build:local -- --archive-only` to preserve existing Tauri output without rebuilding

## Validation

- `bash -n scripts/build-local.sh`
- `pnpm build:local -- --help`
- `git diff --check`
- exercised `--archive-only` with an arm64 app and DMG; verified manifest hashes and `hdiutil verify`

This intentionally remains unsigned for local development and does not replace the notarized release workflow.