### PR TITLE
Improve session workflow reliability and history

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -374,10 +374,11 @@ pub fn record_session_history_activity(
 #[tauri::command]
 pub fn list_session_history(
     project_path: Option<String>,
+    query: Option<String>,
     limit: Option<u32>,
     db: State<'_, UsageDb>,
 ) -> Result<Vec<SessionHistoryEntry>, String> {
-    session_history::list(db.inner(), project_path.as_deref(), limit)
+    session_history::list(db.inner(), project_path.as_deref(), query.as_deref(), limit)
 }
 
 // ── App lifecycle commands ────────────────────────────────────────

--- a/src-tauri/src/session_history.rs
+++ b/src-tauri/src/session_history.rs
@@ -1,5 +1,5 @@
 use crate::usage::UsageDb;
-use rusqlite::{params, Connection};
+use rusqlite::{params, params_from_iter, types::Value, Connection};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -117,40 +117,60 @@ pub fn record_activity(
 pub fn list(
     db: &UsageDb,
     project_path: Option<&str>,
+    query: Option<&str>,
     limit: Option<u32>,
 ) -> Result<Vec<SessionHistoryEntry>, String> {
     let conn = db
         .conn
         .lock()
         .map_err(|_| "Session history database lock was poisoned".to_string())?;
-    list_from_connection(&conn, project_path, limit)
+    list_from_connection(&conn, project_path, query, limit)
 }
 
 fn list_from_connection(
     conn: &Connection,
     project_path: Option<&str>,
+    query: Option<&str>,
     limit: Option<u32>,
 ) -> Result<Vec<SessionHistoryEntry>, String> {
     let limit = i64::from(limit.unwrap_or(50).clamp(1, 200));
     let columns = "provider, session_id, project_path, title, model,
                    started_at, last_activity_at, ended_at";
-    let (sql, project) = match project_path.map(str::trim).filter(|path| !path.is_empty()) {
-        Some(path) => (
-            format!(
-                "SELECT {columns} FROM session_history
-                 WHERE project_path = ?1
-                 ORDER BY last_activity_at DESC LIMIT ?2"
-            ),
-            Some(path),
-        ),
-        None => (
-            format!(
-                "SELECT {columns} FROM session_history
-                 ORDER BY last_activity_at DESC LIMIT ?1"
-            ),
-            None,
-        ),
-    };
+    let project = project_path.map(str::trim).filter(|path| !path.is_empty());
+    let query = query.map(str::trim).filter(|value| !value.is_empty());
+    let mut filters = Vec::new();
+    let mut values = Vec::new();
+
+    if let Some(project) = project {
+        values.push(Value::Text(project.to_string()));
+        filters.push(format!("project_path = ?{}", values.len()));
+    }
+
+    if let Some(query) = query {
+        let escaped = query
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        values.push(Value::Text(format!("%{escaped}%")));
+        let parameter = format!("?{}", values.len());
+        filters.push(format!(
+            "(title LIKE {parameter} ESCAPE '\\' COLLATE NOCASE
+              OR provider LIKE {parameter} ESCAPE '\\' COLLATE NOCASE
+              OR project_path LIKE {parameter} ESCAPE '\\' COLLATE NOCASE
+              OR model LIKE {parameter} ESCAPE '\\' COLLATE NOCASE)"
+        ));
+    }
+
+    let mut sql = format!("SELECT {columns} FROM session_history");
+    if !filters.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&filters.join(" AND "));
+    }
+    values.push(Value::Integer(limit));
+    sql.push_str(&format!(
+        " ORDER BY last_activity_at DESC LIMIT ?{}",
+        values.len()
+    ));
 
     let mut statement = conn
         .prepare(&sql)
@@ -167,12 +187,9 @@ fn list_from_connection(
             ended_at: row.get(7)?,
         })
     };
-    let rows = if let Some(project) = project {
-        statement.query_map(params![project, limit], map_row)
-    } else {
-        statement.query_map(params![limit], map_row)
-    }
-    .map_err(|error| format!("Failed to query session history: {error}"))?;
+    let rows = statement
+        .query_map(params_from_iter(values.iter()), map_row)
+        .map_err(|error| format!("Failed to query session history: {error}"))?;
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("Failed to read session history: {error}"))
@@ -238,7 +255,7 @@ mod tests {
         .unwrap();
         record_activity(&db, "codex", "session-1", 1_500, true).unwrap();
 
-        let project_rows = list(&db, Some("/repo"), Some(10)).unwrap();
+        let project_rows = list(&db, Some("/repo"), None, Some(10)).unwrap();
         assert_eq!(project_rows.len(), 1);
         assert_eq!(
             project_rows[0],
@@ -254,10 +271,100 @@ mod tests {
             }
         );
 
-        let all_rows = list(&db, None, Some(10)).unwrap();
+        let all_rows = list(&db, None, None, Some(10)).unwrap();
         assert_eq!(all_rows.len(), 2);
         assert_eq!(all_rows[0].session_id, "session-1");
         assert_eq!(all_rows[1].session_id, "session-2");
+    }
+
+    #[test]
+    fn searches_every_saved_session_before_applying_the_limit() {
+        let db = UsageDb::open_in_memory();
+        upsert(
+            &db,
+            record(
+                "claude",
+                "older-match",
+                "/archive",
+                Some("Needle migration"),
+                Some("Claude Opus"),
+                1,
+                1,
+            ),
+        )
+        .unwrap();
+
+        for index in 0..205 {
+            upsert(
+                &db,
+                record(
+                    "codex",
+                    &format!("recent-{index}"),
+                    "/repo",
+                    Some("Routine task"),
+                    Some("gpt-5"),
+                    index + 2,
+                    index + 2,
+                ),
+            )
+            .unwrap();
+        }
+
+        let recent = list(&db, None, None, Some(200)).unwrap();
+        assert_eq!(recent.len(), 200);
+        assert!(!recent.iter().any(|entry| entry.session_id == "older-match"));
+
+        let matches = list(&db, None, Some("needle"), Some(200)).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].session_id, "older-match");
+    }
+
+    #[test]
+    fn search_respects_project_scope_and_treats_wildcards_literally() {
+        let db = UsageDb::open_in_memory();
+        upsert(
+            &db,
+            record(
+                "opencode",
+                "literal-match",
+                "/repo",
+                Some("Reach 100% coverage"),
+                None,
+                10,
+                10,
+            ),
+        )
+        .unwrap();
+        upsert(
+            &db,
+            record(
+                "opencode",
+                "wildcard-only",
+                "/repo",
+                Some("Reach 100 percent coverage"),
+                None,
+                20,
+                20,
+            ),
+        )
+        .unwrap();
+        upsert(
+            &db,
+            record(
+                "opencode",
+                "other-project",
+                "/other",
+                Some("Reach 100% coverage"),
+                None,
+                30,
+                30,
+            ),
+        )
+        .unwrap();
+
+        let matches = list(&db, Some("/repo"), Some("100%"), Some(200)).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].session_id, "literal-match");
     }
 
     #[test]

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -52,11 +52,12 @@ pub struct EditorSettings {
 pub struct ProjectSettings {
     #[serde(default = "default_true", rename = "autoImportWorktrees")]
     pub auto_import_worktrees: bool,
-    #[serde(default = "default_true", rename = "showAgentSessionsInSidebar")]
-    pub show_agent_sessions_in_sidebar: bool,
     /// Label shown for live agent sessions: "repository" or "title".
     #[serde(default = "default_agent_label_mode", rename = "agentLabelMode")]
     pub agent_label_mode: String,
+    /// Permission mode used when starting or resuming agent sessions.
+    #[serde(default = "default_agent_session_mode", rename = "defaultAgentMode")]
+    pub default_agent_mode: String,
     #[serde(default = "default_true", rename = "showTodos")]
     pub show_todos: bool,
     /// Shape of a lazily created TODO.md: "kanban" (columned board) or "list".
@@ -72,12 +73,16 @@ fn default_agent_label_mode() -> String {
     "repository".to_string()
 }
 
+fn default_agent_session_mode() -> String {
+    "yolo".to_string()
+}
+
 impl Default for ProjectSettings {
     fn default() -> Self {
         ProjectSettings {
             auto_import_worktrees: true,
-            show_agent_sessions_in_sidebar: true,
             agent_label_mode: default_agent_label_mode(),
+            default_agent_mode: default_agent_session_mode(),
             show_todos: true,
             todo_file_style: default_todo_file_style(),
         }
@@ -335,4 +340,30 @@ pub struct WorkspaceConfig {
     pub commands: Vec<CommandConfig>,
     #[serde(default)]
     pub assistants: Vec<AssistantConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_settings_default_agent_mode_to_yolo() {
+        let settings: ProjectSettings = serde_yaml::from_str(
+            "autoImportWorktrees: true\nagentLabelMode: repository\nshowTodos: true\ntodoFileStyle: kanban\n",
+        )
+        .unwrap();
+
+        assert_eq!(settings.default_agent_mode, "yolo");
+        assert_eq!(ProjectSettings::default().default_agent_mode, "yolo");
+    }
+
+    #[test]
+    fn project_settings_preserve_an_explicit_standard_agent_mode() {
+        let settings: ProjectSettings = serde_yaml::from_str(
+            "autoImportWorktrees: true\ndefaultAgentMode: standard\nshowTodos: true\ntodoFileStyle: kanban\n",
+        )
+        .unwrap();
+
+        assert_eq!(settings.default_agent_mode, "standard");
+    }
 }

--- a/src/components/history/HistoryPanel.tsx
+++ b/src/components/history/HistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight, Clock3, LoaderCircle, RefreshCcw, Search } from "lucide-react";
 import { CODING_ASSISTANTS } from "../sidebar/constants";
 import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogos";
@@ -78,11 +78,13 @@ export default function HistoryPanel({
 }: HistoryPanelProps) {
   const [scope, setScope] = useState<HistoryScope>("all");
   const [query, setQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
   const [sessions, setSessions] = useState<SessionHistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [availableProviders, setAvailableProviders] = useState<Record<string, boolean>>({});
   const [resumingKey, setResumingKey] = useState<string | null>(null);
+  const loadRequestId = useRef(0);
   const projectState = useTerminalStore((state) => state.projectState);
   const tabActivity = useTerminalStore((state) => state.tabActivity);
 
@@ -90,18 +92,26 @@ export default function HistoryPanel({
     if (!activeRepoPath && scope === "project") setScope("all");
   }, [activeRepoPath, scope]);
 
+  useEffect(() => {
+    const timer = window.setTimeout(() => setSearchQuery(query.trim()), 200);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
   const loadSessions = useCallback(async () => {
+    const requestId = loadRequestId.current + 1;
+    loadRequestId.current = requestId;
     setLoading(true);
     setError(null);
     try {
       const projectPath = scope === "project" ? activeRepoPath : null;
-      setSessions(await listSessionHistory(projectPath, 200));
+      const nextSessions = await listSessionHistory(projectPath, searchQuery || null, 200);
+      if (loadRequestId.current === requestId) setSessions(nextSessions);
     } catch (loadError) {
-      setError(getErrorMessage(loadError));
+      if (loadRequestId.current === requestId) setError(getErrorMessage(loadError));
     } finally {
-      setLoading(false);
+      if (loadRequestId.current === requestId) setLoading(false);
     }
-  }, [activeRepoPath, scope]);
+  }, [activeRepoPath, scope, searchQuery]);
 
   useEffect(() => {
     void loadSessions();
@@ -137,21 +147,6 @@ export default function HistoryPanel({
     return keys;
   }, [projectState, tabActivity]);
 
-  const filteredSessions = useMemo(() => {
-    const needle = query.trim().toLocaleLowerCase();
-    if (!needle) return sessions;
-    return sessions.filter((session) =>
-      [
-        session.title,
-        providerLabel(session.provider),
-        session.provider,
-        projectName(session.projectPath),
-        session.projectPath,
-        session.model,
-      ].some((value) => value?.toLocaleLowerCase().includes(needle)),
-    );
-  }, [query, sessions]);
-
   const selectedProjectName = activeRepoPath ? projectName(activeRepoPath) : null;
   const knownProjects = useMemo(() => new Set(knownRepoPaths), [knownRepoPaths]);
 
@@ -171,7 +166,7 @@ export default function HistoryPanel({
         <div>
           <h2 className="history-panel__title">Session history</h2>
           <p className="history-panel__description">
-            Find conversations Shep has seen. Resume actions are coming next.
+            Find and resume conversations Shep has seen.
           </p>
         </div>
         <button
@@ -223,7 +218,11 @@ export default function HistoryPanel({
           {scope === "project" && selectedProjectName ? selectedProjectName : "All projects"}
         </span>
         {!loading && !error && (
-          <span>{filteredSessions.length}{query.trim() ? ` of ${sessions.length}` : ""} sessions</span>
+          <span>
+            {searchQuery
+              ? `${sessions.length === 200 ? "First " : ""}${sessions.length} matching sessions`
+              : `${sessions.length} sessions`}
+          </span>
         )}
       </div>
 
@@ -241,21 +240,21 @@ export default function HistoryPanel({
         </div>
       )}
 
-      {!error && !loading && filteredSessions.length === 0 && (
+      {!error && !loading && sessions.length === 0 && (
         <div className="history-state">
           <Clock3 size={20} />
-          <strong>{query.trim() ? "No matching sessions" : "No saved sessions yet"}</strong>
+          <strong>{searchQuery ? "No matching sessions" : "No saved sessions yet"}</strong>
           <span>
-            {query.trim()
+            {searchQuery
               ? "Try a title, provider, repository, or model."
               : "New agent sessions appear here after Shep discovers their provider session ID."}
           </span>
         </div>
       )}
 
-      {!error && filteredSessions.length > 0 && (
+      {!error && sessions.length > 0 && (
         <div className="history-list" role="list" aria-label="Saved agent sessions">
-          {filteredSessions.map((session) => {
+          {sessions.map((session) => {
             const key = sessionKey(session.provider, session.sessionId);
             const isActive = activeSessions.has(key);
             const logoSrc = assistantLogoSrc[session.provider];

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -25,6 +25,7 @@ import { useEditorStore } from "../../stores/useEditorStore";
 import { useTerminalSettingsStore } from "../../stores/useTerminalSettingsStore";
 import { useUsageStore } from "../../stores/useUsageStore";
 import { useUsageSettingsStore } from "../../stores/useUsageSettingsStore";
+import { useProjectSettingsStore } from "../../stores/useProjectSettingsStore";
 import { useUpdateStore } from "../../stores/useUpdateStore";
 import { initNotifications } from "../../lib/notifications";
 import { getErrorMessage } from "../../lib/errors";
@@ -170,6 +171,7 @@ export default function AppShell() {
   // Derive which kind of local tab is active (for panel content rendering)
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const { loadSettings: loadEditorSettings } = useEditorStore.getState();
+  const { loadSettings: loadProjectSettings } = useProjectSettingsStore.getState();
   const { loadSettings: loadTerminalSettings } = useTerminalSettingsStore.getState();
   const { fetchSnapshots: fetchUsageSnapshots } = useUsageStore.getState();
   const { loadSettings: loadUsageSettings } = useUsageSettingsStore.getState();
@@ -178,6 +180,7 @@ export default function AppShell() {
     fetchRepos();
     fetchGroups();
     void loadEditorSettings();
+    void loadProjectSettings();
     void loadTerminalSettings();
     void loadUsageSettings();
     void fetchUsageSnapshots();
@@ -204,7 +207,7 @@ export default function AppShell() {
       window.clearTimeout(updateTimer);
       window.clearTimeout(usageRefreshTimer);
     };
-  }, [fetchRepos, fetchGroups, loadEditorSettings, loadTerminalSettings, loadUsageSettings, fetchUsageSnapshots, pushNotice]);
+  }, [fetchRepos, fetchGroups, loadEditorSettings, loadProjectSettings, loadTerminalSettings, loadUsageSettings, fetchUsageSnapshots, pushNotice]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {

--- a/src/components/session/SessionLauncher.tsx
+++ b/src/components/session/SessionLauncher.tsx
@@ -4,6 +4,7 @@ import { CODING_ASSISTANTS } from "../sidebar/constants";
 import { checkCommandExists, getModelsForProvider } from "../../lib/tauri";
 import { useRepoStore } from "../../stores/useRepoStore";
 import { usePiConfigStore } from "../../stores/usePiConfigStore";
+import { useProjectSettingsStore } from "../../stores/useProjectSettingsStore";
 import { HandMetal, ChevronDown, Check, Info, X } from "lucide-react";
 import { assistantLogoSrc, getAssistantLogoClass } from "../../lib/assistantLogos";
 import { ASSISTANT_INSTALL_URLS } from "../sidebar/constants";
@@ -18,11 +19,12 @@ interface SessionLauncherProps {
 
 export default function SessionLauncher({ onStartSession }: SessionLauncherProps) {
   const activeRepoPath = useRepoStore((s) => s.activeRepoPath);
+  const defaultAgentMode = useProjectSettingsStore((s) => s.settings.defaultAgentMode);
 
   const [selectedAssistant, setSelectedAssistant] = useState<CodingAssistant | null>(null);
   const [available, setAvailable] = useState<Record<string, boolean>>({});
   const [installPopover, setInstallPopover] = useState<string | null>(null);
-  const [mode, setMode] = useState<SessionMode>("standard");
+  const [mode, setMode] = useState<SessionMode>(defaultAgentMode);
   const [launching, setLaunching] = useState(false);
 
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
@@ -109,7 +111,11 @@ export default function SessionLauncher({ onStartSession }: SessionLauncherProps
   }, [availableModels, modelSearch, selectedAssistant, selectedPiProvider]);
 
   const supportsModelSelection = (id: string) => id !== "pi" && id !== "opencode";
-  const supportsMode = (id: string) => id !== "pi" && id !== "opencode";
+  const supportsMode = (id: string) => id !== "pi";
+
+  useEffect(() => {
+    setMode(defaultAgentMode);
+  }, [defaultAgentMode]);
 
   const handleSelectAssistant = (assistant: CodingAssistant) => {
     const requestId = modelRequestRef.current + 1;

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -388,19 +388,6 @@ export default function SettingsPanel() {
 
         <div className="settings-row">
           <span className="settings-row__label flex items-center gap-2">
-            <span>Agent Sessions in Sidebar</span>
-            <InfoTip text="Shows the global agent session section above Projects. Project tabs and agent sessions remain available inside each project when this is off." />
-          </span>
-          <button
-            onClick={() => void updateProjectSettings({ showAgentSessionsInSidebar: !projectSettings.showAgentSessionsInSidebar })}
-            className={`option-card option-card--compact ${projectSettings.showAgentSessionsInSidebar ? "selected" : ""}`}
-          >
-            {projectSettings.showAgentSessionsInSidebar ? "On" : "Off"}
-          </button>
-        </div>
-
-        <div className="settings-row">
-          <span className="settings-row__label flex items-center gap-2">
             <span>Agent Label</span>
             <InfoTip text="Choose what identifies live agents in tabs and the sidebar. Session titles are still retained for history when Repository is selected. Manual tab renames always take priority." />
           </span>
@@ -416,6 +403,28 @@ export default function SettingsPanel() {
               className={`option-card option-card--compact ${projectSettings.agentLabelMode === "title" ? "selected" : ""}`}
             >
               Session title
+            </button>
+          </div>
+        </div>
+
+        <div className="settings-row">
+          <span className="settings-row__label flex items-center gap-2">
+            <span>Default Agent Mode</span>
+            <InfoTip text="YOLO starts supported agents with permission checks disabled and also applies when resuming sessions. Pi already runs tools without a separate approval layer." />
+          </span>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => void updateProjectSettings({ defaultAgentMode: "standard" })}
+              className={`option-card option-card--compact ${projectSettings.defaultAgentMode === "standard" ? "selected" : ""}`}
+            >
+              Standard
+            </button>
+            <button
+              onClick={() => void updateProjectSettings({ defaultAgentMode: "yolo" })}
+              className={`option-card option-card--compact ${projectSettings.defaultAgentMode === "yolo" ? "selected" : ""}`}
+              title="Start agents with approval prompts disabled"
+            >
+              YOLO
             </button>
           </div>
         </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -100,15 +100,13 @@ export default function Sidebar({
   return (
     <div className="w-72 shrink-0 flex flex-col h-full pr-4 mr-4 border-r border-[var(--glass-border)]" onContextMenu={(e) => e.preventDefault()}>
       <div className="flex-1 overflow-y-auto min-h-0">
-        {projectSettings.showAgentSessionsInSidebar && (
-          <AgentSessionList
-            sessions={agentSessions}
-            activeRepoPath={activeRepoPath}
-            activeTabId={activeTabId}
-            labelMode={projectSettings.agentLabelMode}
-            onSelectSession={onSelectProjectTab}
-          />
-        )}
+        <AgentSessionList
+          sessions={agentSessions}
+          activeRepoPath={activeRepoPath}
+          activeTabId={activeTabId}
+          labelMode={projectSettings.agentLabelMode}
+          onSelectSession={onSelectProjectTab}
+        />
         <div className="sidebar-section px-2 pb-2">
           <SidebarSectionToggle
             label="Projects"

--- a/src/components/sidebar/constants.ts
+++ b/src/components/sidebar/constants.ts
@@ -4,7 +4,7 @@ export const CODING_ASSISTANTS: CodingAssistant[] = [
   { id: "claude", name: "Claude Code", command: "claude", yoloFlag: "--dangerously-skip-permissions", modelFlag: "--model" },
   { id: "codex", name: "Codex", command: "codex", yoloFlag: "--yolo", modelFlag: "--model" },
   { id: "antigravity", name: "Antigravity", command: "agy", yoloFlag: "--dangerously-skip-permissions", modelFlag: "--model" },
-  { id: "opencode", name: "Open Code", command: "opencode", yoloFlag: null, modelFlag: "--model" },
+  { id: "opencode", name: "Open Code", command: "opencode", yoloFlag: "--auto", modelFlag: "--model" },
   { id: "pi", name: "pi", command: "pi", yoloFlag: null, modelFlag: "--model" },
 ];
 

--- a/src/hooks/usePty.ts
+++ b/src/hooks/usePty.ts
@@ -24,6 +24,7 @@ import { useCommandStore } from "../stores/useCommandStore";
 import { useTerminalStore, nextTabId } from "../stores/useTerminalStore";
 import { useRepoStore } from "../stores/useRepoStore";
 import { useNoticeStore } from "../stores/useNoticeStore";
+import { useProjectSettingsStore } from "../stores/useProjectSettingsStore";
 import { CODING_ASSISTANTS } from "../components/sidebar/constants";
 import type { Terminal } from "@xterm/xterm";
 import { getErrorMessage } from "../lib/errors";
@@ -962,7 +963,11 @@ export function usePty() {
   const resumeAssistant = useCallback(
     async (session: SessionHistoryEntry, cols: number, rows: number) => {
       const assistant = CODING_ASSISTANTS.find((entry) => entry.id === session.provider);
-      const commandArgs = sessionResumeArgs(session.provider, session.sessionId);
+      const resumeArgs = sessionResumeArgs(session.provider, session.sessionId);
+      const mode = useProjectSettingsStore.getState().settings.defaultAgentMode;
+      const commandArgs = resumeArgs && mode === "yolo" && assistant?.yoloFlag
+        ? [assistant.yoloFlag, ...resumeArgs]
+        : resumeArgs;
       if (!assistant || !commandArgs) {
         pushNotice({
           tone: "error",
@@ -994,7 +999,7 @@ export function usePty() {
           commandName: null,
           assistantId: session.provider,
           providerSessionId: session.sessionId,
-          sessionMode: "standard",
+          sessionMode: mode,
           labelSource: session.title ? "session" : "default",
         });
 

--- a/src/lib/agentScreenStatus.ts
+++ b/src/lib/agentScreenStatus.ts
@@ -246,7 +246,8 @@ function detectCodex(screen: string, title: string): AgentScreenDetection {
 
 function detectAntigravity(screen: string): AgentScreenDetection {
   const lower = screen.toLocaleLowerCase();
-  const recent = lastNonEmptyLines(screen, 8);
+  const recent = lastNonEmptyLines(screen, 12);
+  const recentLower = recent.toLocaleLowerCase();
 
   if (
     lower.includes("requesting permission for:") &&
@@ -257,6 +258,19 @@ function detectAntigravity(screen: string): AgentScreenDetection {
       "antigravity-permission-prompt",
       "Antigravity is visibly requesting permission",
       evidenceFor(screen, "requesting permission for:"),
+    );
+  }
+
+  if (
+    /question\s+\d+\s*\/\s*\d+\s*:/iu.test(recent) &&
+    recentLower.includes("enter select") &&
+    recentLower.includes("esc skip")
+  ) {
+    return matched(
+      "blocked",
+      "antigravity-question",
+      "Antigravity is waiting for an answer to a visible question",
+      evidenceFor(recent, "question"),
     );
   }
 
@@ -281,6 +295,15 @@ function detectAntigravity(screen: string): AgentScreenDetection {
       "antigravity-background-tasks",
       "Antigravity reports active background tasks",
       taskLine.trim(),
+    );
+  }
+
+  if (/^\s*>\s*$/mu.test(recent) && recentLower.includes("? for shortcuts")) {
+    return matched(
+      "idle",
+      "antigravity-live-prompt",
+      "Antigravity's live prompt is ready for input",
+      evidenceFor(recent, "? for shortcuts"),
     );
   }
 
@@ -312,7 +335,12 @@ function detectOpenCode(screen: string): AgentScreenDetection {
     );
   }
 
-  const interruptHint = ["esc to interrupt", "ctrl+c to interrupt", "press esc to interrupt"]
+  const interruptHint = [
+    "esc interrupt",
+    "esc to interrupt",
+    "ctrl+c to interrupt",
+    "press esc to interrupt",
+  ]
     .find((needle) => lower.includes(needle));
   if (interruptHint) {
     return matched(
@@ -332,12 +360,52 @@ function detectOpenCode(screen: string): AgentScreenDetection {
     );
   }
 
+  const spinnerLine = recent
+    .split("\n")
+    .find((line) => /^\s*[\u2800-\u28ff]+\s+(?:Thinking|Working)\b/iu.test(line));
+  if (spinnerLine) {
+    return matched(
+      "working",
+      "opencode-spinner",
+      "OpenCode's working spinner is visible",
+      spinnerLine.trim(),
+    );
+  }
+
+  const idleHint = ["ask anything...", "ctrl+p commands"]
+    .find((needle) => lower.includes(needle));
+  if (idleHint) {
+    return matched(
+      "idle",
+      "opencode-live-prompt",
+      "OpenCode's live prompt is ready for input",
+      evidenceFor(recent, idleHint),
+    );
+  }
+
   return fallback("OpenCode");
 }
 
 function detectPi(screen: string): AgentScreenDetection {
-  const recent = lastNonEmptyLines(screen, 8);
-  if (recent.includes("Working...")) {
+  const recent = lastNonEmptyLines(screen, 12);
+  const lower = recent.toLocaleLowerCase();
+
+  const inputFooter = lower.includes("enter submit") && (
+    lower.includes("esc cancel") || lower.includes("escape cancel")
+  );
+  const questionSelector = lower.includes("question") &&
+    lower.includes("enter select") &&
+    (lower.includes("esc cancel") || lower.includes("esc dismiss"));
+  if (inputFooter || questionSelector) {
+    return matched(
+      "blocked",
+      "pi-extension-input",
+      "Pi is waiting for input from a visible extension form",
+      evidenceFor(recent, inputFooter ? "enter submit" : "enter select"),
+    );
+  }
+
+  if (lower.includes("working...")) {
     return matched(
       "working",
       "pi-working-literal",
@@ -345,6 +413,16 @@ function detectPi(screen: string): AgentScreenDetection {
       evidenceFor(recent, "Working..."),
     );
   }
+
+  if (lower.includes("mcp:") || lower.includes("ctrl+c/ctrl+d clear/exit")) {
+    return matched(
+      "idle",
+      "pi-live-prompt",
+      "Pi's live prompt is ready for input",
+      evidenceFor(recent, lower.includes("mcp:") ? "MCP:" : "ctrl+c/ctrl+d clear/exit"),
+    );
+  }
+
   return fallback("Pi");
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -243,9 +243,10 @@ export function recordSessionHistoryActivity(
 
 export function listSessionHistory(
   projectPath: string | null = null,
+  query: string | null = null,
   limit = 50,
 ): Promise<SessionHistoryEntry[]> {
-  return invoke("list_session_history", { projectPath, limit });
+  return invoke("list_session_history", { projectPath, query, limit });
 }
 
 // ── App lifecycle commands ────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,8 +42,8 @@ export type AgentLabelMode = "repository" | "title";
 
 export interface ProjectSettings {
   autoImportWorktrees: boolean;
-  showAgentSessionsInSidebar: boolean;
   agentLabelMode: AgentLabelMode;
+  defaultAgentMode: SessionMode;
   showTodos: boolean;
   /** Shape of a lazily created TODO.md. */
   todoFileStyle: TodoFileStyle;

--- a/src/stores/useProjectSettingsStore.ts
+++ b/src/stores/useProjectSettingsStore.ts
@@ -4,8 +4,8 @@ import { getProjectSettings, saveProjectSettings } from "../lib/tauri";
 
 const DEFAULT_SETTINGS: ProjectSettings = {
   autoImportWorktrees: true,
-  showAgentSessionsInSidebar: true,
   agentLabelMode: "repository",
+  defaultAgentMode: "yolo",
   showTodos: true,
   todoFileStyle: "kanban",
 };
@@ -28,7 +28,14 @@ export const useProjectSettingsStore = create<ProjectSettingsStore>((set, get) =
   loadSettings: async () => {
     try {
       const settings = await getProjectSettings();
-      set({ settings, hasLoaded: true, error: null });
+      set({
+        settings: {
+          ...settings,
+          defaultAgentMode: settings.defaultAgentMode === "standard" ? "standard" : "yolo",
+        },
+        hasLoaded: true,
+        error: null,
+      });
     } catch (error) {
       set({ settings: DEFAULT_SETTINGS, hasLoaded: true, error: String(error) });
     }

--- a/tests/agentScreenStatus.test.ts
+++ b/tests/agentScreenStatus.test.ts
@@ -16,6 +16,15 @@ test("Claude visible confirmation is blocked", () => {
   assert.equal(result.ruleId, "claude-live-form");
 });
 
+test("Claude current permission prompt is blocked", () => {
+  const result = detectAgentScreenStatus(
+    "claude",
+    "Bash command\nDo you want to proceed?\nEsc to cancel · Tab to amend · ctrl+e to explain",
+  );
+  assert.equal(result.state, "blocked");
+  assert.equal(result.ruleId, "claude-live-form");
+});
+
 test("Claude working title is working", () => {
   const result = detectAgentScreenStatus("claude", "Implementing changes", "* shep");
   assert.equal(result.state, "working");
@@ -42,6 +51,15 @@ test("Codex action-required title is blocked", () => {
   assert.equal(result.state, "blocked");
 });
 
+test("Codex current command approval is blocked", () => {
+  const result = detectAgentScreenStatus(
+    "codex",
+    "Would you like to run the following command?\nYes, proceed (y)\nPress enter to confirm or esc to cancel",
+  );
+  assert.equal(result.state, "blocked");
+  assert.equal(result.ruleId, "codex-live-blocker");
+});
+
 test("Codex working row is working", () => {
   const result = detectAgentScreenStatus(
     "codex",
@@ -66,8 +84,26 @@ test("Antigravity permission UI is blocked", () => {
 });
 
 test("Antigravity spinner is working", () => {
-  const result = detectAgentScreenStatus("antigravity", "⠋ Thinking about the change");
+  const result = detectAgentScreenStatus("antigravity", "⣾  Generating...\nesc to cancel");
   assert.equal(result.state, "working");
+});
+
+test("Antigravity question UI is blocked", () => {
+  const result = detectAgentScreenStatus(
+    "antigravity",
+    "Question 1/1: What would you like to focus on next?\nOption one\n↑/↓ Navigate · enter Select · esc Skip",
+  );
+  assert.equal(result.state, "blocked");
+  assert.equal(result.ruleId, "antigravity-question");
+});
+
+test("Antigravity live prompt is explicit idle", () => {
+  const result = detectAgentScreenStatus(
+    "antigravity",
+    ">\n? for shortcuts\nGemini 3.5 Flash · high",
+  );
+  assert.equal(result.state, "idle");
+  assert.equal(result.ruleId, "antigravity-live-prompt");
 });
 
 test("OpenCode permission UI is blocked", () => {
@@ -76,13 +112,58 @@ test("OpenCode permission UI is blocked", () => {
 });
 
 test("OpenCode interrupt hint is working", () => {
-  const result = detectAgentScreenStatus("opencode", "Updating files · esc to interrupt");
+  const result = detectAgentScreenStatus("opencode", "Updating files · esc interrupt");
   assert.equal(result.state, "working");
 });
 
+test("OpenCode question UI is blocked", () => {
+  const result = detectAgentScreenStatus(
+    "opencode",
+    "Choose a direction\n↑↓ select  enter submit  esc dismiss",
+  );
+  assert.equal(result.state, "blocked");
+  assert.equal(result.ruleId, "opencode-question");
+});
+
+test("OpenCode live prompt is explicit idle", () => {
+  const result = detectAgentScreenStatus(
+    "opencode",
+    "Ask anything... \"Fix broken tests\"\ntab agents  ctrl+p commands\n~/dev/shep:main",
+  );
+  assert.equal(result.state, "idle");
+  assert.equal(result.ruleId, "opencode-live-prompt");
+});
+
 test("Pi working literal is working", () => {
-  const result = detectAgentScreenStatus("pi", "Working...");
+  const result = detectAgentScreenStatus("pi", "⠋ Working...");
   assert.equal(result.state, "working");
+});
+
+test("Pi extension input is blocked", () => {
+  const result = detectAgentScreenStatus(
+    "pi",
+    "What should the agent do next?\nenter submit  esc cancel\nMCP: 0/1 servers",
+  );
+  assert.equal(result.state, "blocked");
+  assert.equal(result.ruleId, "pi-extension-input");
+});
+
+test("Pi live prompt is explicit idle", () => {
+  const result = detectAgentScreenStatus(
+    "pi",
+    "~/dev/shep (main)\ncontext 2% (auto)\nMCP: 0/1 servers",
+  );
+  assert.equal(result.state, "idle");
+  assert.equal(result.ruleId, "pi-live-prompt");
+});
+
+test("Pi model picker remains idle rather than looking blocked", () => {
+  const result = detectAgentScreenStatus(
+    "pi",
+    "→ grok-4.5 [xai] ✓\nModel Name: Grok 4.5\n↑↓ navigate  enter select  esc cancel\nMCP: 0/1 servers",
+  );
+  assert.equal(result.state, "idle");
+  assert.equal(result.ruleId, "pi-live-prompt");
 });
 
 test("Known providers conservatively fall back to idle", () => {


### PR DESCRIPTION
## Agreed scope

- Linked issue: Internal release integration; no public issue
- Maintainer who confirmed the approach: @stumptowndoug

## Summary

- keep Agent Sessions visible and improve working, idle, blocked, and stuck detection across all five supported CLIs
- search the complete SQLite session history before applying the 200-result display cap
- default new and resumed agent sessions to the saved YOLO mode, including OpenCode auto-approval

## Validation

- `cargo test` — 66 passed
- `pnpm test:agent-status` — 30 passed
- `pnpm run build`
- live status smoke tests against Claude, Codex, Antigravity, OpenCode, and Pi
- verified YOLO/resume flag parsing with installed Claude, Codex, Antigravity, and OpenCode CLIs

## Checklist

- [x] This pull request addresses the agreed internal release scope.
- [x] It contains no unrelated cleanup or refactors.
- [x] The commit history is focused and ready for review.
- [x] Relevant tests are included.