### PR TITLE
Fix Claude session discovery for repo paths with non-alphanumeric characters

### DIFF
--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -755,7 +755,7 @@ fn resolve_claude(
 ) -> Option<SessionTitleMatch> {
     let directory = home
         .join(".claude/projects")
-        .join(repo_path.replace(['/', '\\', ':'], "-"));
+        .join(claude_project_directory(repo_path));
     let pid_session_id = session_id
         .map(ToString::to_string)
         .or_else(|| claude_pid_session_id(home, repo_path, process_id));
@@ -766,6 +766,22 @@ fn resolve_claude(
         pid_session_id.as_deref(),
         JsonlProvider::Claude,
     )
+}
+
+// Claude Code names each project directory by replacing every non-alphanumeric
+// character in the cwd with a dash (e.g. /Users/doug.dement/dev/shep →
+// -Users-doug-dement-dev-shep).
+fn claude_project_directory(repo_path: &str) -> String {
+    repo_path
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 fn claude_pid_session_id(home: &Path, repo_path: &str, process_id: Option<u32>) -> Option<String> {
@@ -1458,6 +1474,40 @@ mod tests {
 
         let found = resolve_session_title_from_home(&home, "claude", repo, started, None, Some(42))
             .unwrap();
+        assert_eq!(found.session_id, "session-1");
+        assert_eq!(found.title.as_deref(), Some("restore sessions"));
+
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn claude_project_directory_replaces_every_non_alphanumeric_character() {
+        assert_eq!(
+            claude_project_directory("/Users/doug.dement/dev/my_repo v2"),
+            "-Users-doug-dement-dev-my-repo-v2"
+        );
+    }
+
+    #[test]
+    fn claude_finds_transcripts_when_the_repo_path_contains_dots() {
+        let home = temp_home();
+        let repo = "/Users/doug.dement/dev/testing";
+        let dir = home
+            .join(".claude/projects")
+            .join("-Users-doug-dement-dev-testing");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("session-1.jsonl"),
+            concat!(
+                "{\"type\":\"mode\",\"sessionId\":\"session-1\"}\n",
+                "{\"type\":\"user\",\"cwd\":\"/Users/doug.dement/dev/testing\",\"timestamp\":\"2026-08-07T12:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"Is this more about being able to restore sessions?\"}}\n"
+            ),
+        )
+        .unwrap();
+        let started = parse_timestamp_ms("2026-08-07T12:00:00Z").unwrap();
+
+        let found =
+            resolve_session_title_from_home(&home, "claude", repo, started, None, None).unwrap();
         assert_eq!(found.session_id, "session-1");
         assert_eq!(found.title.as_deref(), Some("restore sessions"));
 


### PR DESCRIPTION
## Problem

The History panel never populates (and Claude tab titles never resolve) on machines where repo paths contain a dot, underscore, or space — e.g. a home directory like `/Users/doug.dement`.

`resolve_claude` in `session_titles.rs` rebuilt the `~/.claude/projects` folder name with `repo_path.replace(['/', '\\', ':'], "-")`, but Claude Code names these folders by replacing **every** non-alphanumeric character with a dash:

- Shep looked for `~/.claude/projects/-Users-doug.dement-dev-testing` (doesn't exist)
- Claude Code writes `~/.claude/projects/-Users-doug-dement-dev-testing`

Since session history rows are only written after this discovery succeeds, discovery failed 100% of the time on affected machines and `session_history` stayed empty forever. Usage tracking was unaffected because ingest walks all project directories instead of reconstructing names.

## Fix

New `claude_project_directory` helper that replaces every non-ASCII-alphanumeric character with `-`, matching Claude Code's convention. The pi resolver's separate convention was verified correct against real on-disk directories (pi preserves dots) and is untouched.

## Tests

- Unit test asserting the munging for dots, underscores, and spaces
- End-to-end resolver test for a repo path containing a dot
- All existing `session_titles` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnd6H6Wu9KP5gCVzxAmkQ6