### PR TITLE
Allow starting Pi when default mode is YOLO

### DIFF
--- a/src/components/session/SessionLauncher.tsx
+++ b/src/components/session/SessionLauncher.tsx
@@ -512,7 +512,7 @@ export default function SessionLauncher({ onStartSession }: SessionLauncherProps
           <label className="section-label !p-0 mb-3 block text-xs opacity-50">Start</label>
           <button
             className="btn-cta"
-            disabled={launching || (mode === "yolo" && !supportsYolo)}
+            disabled={launching}
             aria-busy={launching}
             onClick={handleStart}
           >


### PR DESCRIPTION
## Summary
- Pi has no YOLO CLI flag because it already auto-accepts by default.
- The Start Session button stayed disabled whenever the saved default agent mode was YOLO, so Pi looked unlaunchable.
- Launch already omits a missing YOLO flag, so the button now only disables while a session is starting.

## Test plan
- [ ] Set default agent mode to YOLO in Settings
- [ ] Open the agent launcher, select Pi, confirm Start Session is enabled and readable
- [ ] Start a Pi session and confirm it launches
- [ ] Confirm other agents still start in YOLO when that is the default