### PR TITLE
Add Cursor token and model usage from billing aggregates

### DIFF
--- a/src-tauri/src/usage/mod.rs
+++ b/src-tauri/src/usage/mod.rs
@@ -11,7 +11,9 @@ pub use types::{LocalUsageDetails, ProviderUsageSnapshot, UsageOverview, UsagePr
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Emitter;
-use types::UsageWindowSnapshot;
+use types::{
+    UsageBreakdownItem, UsageCost, UsageOverviewProvider, UsageWindowSnapshot,
+};
 use helpers::now_epoch_seconds;
 
 /// Cooldown after a successful provider API call.
@@ -86,7 +88,7 @@ impl ProviderState {
 enum ProviderCacheData {
     Claude(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>),
     Codex(Vec<UsageWindowSnapshot>),
-    Cursor(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>),
+    Cursor(providers::CursorProviderData),
     Gemini(Vec<UsageWindowSnapshot>),
     Antigravity(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>),
     Grok(Vec<UsageWindowSnapshot>),
@@ -176,8 +178,10 @@ pub fn get_windowed_details(db: &UsageDb, provider: &str, window: &str) -> Resul
 
 pub fn get_usage_overview(db: &UsageDb, window: &str) -> Result<UsageOverview, String> {
     let conn = db.conn.lock().unwrap();
-    queries::usage_overview(&conn, window)
-        .ok_or_else(|| format!("Unsupported usage overview window: {window}"))
+    let mut overview = queries::usage_overview(&conn, window)
+        .ok_or_else(|| format!("Unsupported usage overview window: {window}"))?;
+    merge_cursor_overview(&mut overview);
+    Ok(overview)
 }
 
 pub fn get_project_alias_review_queue(db: &UsageDb) -> Vec<UsageProjectAliasReviewItem> {
@@ -325,10 +329,10 @@ fn refresh_provider_cache_sync(
     }
 
     if do_cursor {
-        match providers::cursor_provider_windows() {
+        match providers::cursor_provider_data() {
             Ok(data) => {
                 let mut cache = PROVIDER_CACHE.lock().unwrap();
-                cache.cursor.cache = Some(ProviderCacheData::Cursor(data.0, data.1));
+                cache.cursor.cache = Some(ProviderCacheData::Cursor(data));
                 cache.cursor.record_success(now);
             }
             Err(e) => {
@@ -453,7 +457,7 @@ fn cursor_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
     let fetched_at = helpers::now_iso_string();
     let cache = PROVIDER_CACHE.lock().unwrap();
     let cached_data = match &cache.cursor.cache {
-        Some(ProviderCacheData::Cursor(summary, extra)) => Some((summary.clone(), extra.clone())),
+        Some(ProviderCacheData::Cursor(data)) => Some(data.clone()),
         _ => None,
     };
     let error = if cached_data.is_none() && !cache.cursor.last_error.is_empty() {
@@ -464,16 +468,97 @@ fn cursor_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
     drop(cache);
     let _ = conn;
 
-    let (summary_windows, extra_windows) = cached_data.unwrap_or_default();
+    let local_details = cached_data.as_ref().and_then(providers::cursor_local_details);
+    let (summary_windows, extra_windows) = cached_data
+        .map(|data| (data.summary, data.extra))
+        .unwrap_or_default();
     ProviderUsageSnapshot {
         provider: "cursor".to_string(),
         status: if summary_windows.is_empty() { "unavailable".to_string() } else { "ready".to_string() },
         fetched_at,
         summary_windows,
         extra_windows,
-        local_details: None,
+        local_details,
         error,
     }
+}
+
+fn cursor_included_cost(amount: Option<f64>) -> UsageCost {
+    UsageCost {
+        amount,
+        kind: "included".to_string(),
+        basis: "subscription".to_string(),
+        confidence: "official".to_string(),
+    }
+}
+
+fn merge_cursor_overview(overview: &mut UsageOverview) {
+    let cache = PROVIDER_CACHE.lock().unwrap();
+    let Some(ProviderCacheData::Cursor(data)) = &cache.cursor.cache else {
+        return;
+    };
+    let Some(aggregate) = providers::cursor_window_for_overview(data, &overview.window) else {
+        return;
+    };
+    let aggregate = aggregate.clone();
+    drop(cache);
+
+    overview.providers.retain(|provider| provider.provider != "cursor");
+    overview.top_models.retain(|item| item.provider != "cursor");
+
+    let tokens = aggregate.tokens_total();
+    let cost_detail = cursor_included_cost(aggregate.cost);
+    overview.providers.push(UsageOverviewProvider {
+        provider: "cursor".to_string(),
+        tokens,
+        tokens_input: aggregate.tokens_input,
+        tokens_output: aggregate.tokens_output,
+        tokens_cache_read: aggregate.tokens_cache_read,
+        tokens_cache_write: aggregate.tokens_cache_write,
+        tokens_thoughts: 0,
+        cost: aggregate.cost,
+        cost_detail: cost_detail.clone(),
+        share_percent: 0.0,
+        trend: overview.trend.iter().map(|_| 0).collect(),
+    });
+
+    for model in &aggregate.models {
+        overview.top_models.push(UsageBreakdownItem {
+            provider: "cursor".to_string(),
+            label: model.name.clone(),
+            tokens: model.tokens_total(),
+            tokens_input: model.tokens_input,
+            tokens_output: model.tokens_output,
+            tokens_cache_read: model.tokens_cache_read,
+            tokens_cache_write: model.tokens_cache_write,
+            tokens_thoughts: 0,
+            cost: model.cost,
+            cost_detail: cursor_included_cost(model.cost),
+            sessions: None,
+            trend: overview.trend.iter().map(|_| 0).collect(),
+        });
+    }
+
+    overview.providers.sort_by(|a, b| b.tokens.cmp(&a.tokens));
+    overview.top_models.sort_by(|a, b| b.tokens.cmp(&a.tokens));
+    overview.top_models.truncate(25);
+
+    overview.total_tokens = overview.providers.iter().map(|provider| provider.tokens).sum();
+    let total_cost_value: f64 = overview.providers.iter().filter_map(|provider| provider.cost).sum();
+    overview.total_cost = overview.providers.iter().any(|provider| provider.cost.is_some()).then_some(total_cost_value);
+    for provider in &mut overview.providers {
+        provider.share_percent = if overview.total_tokens > 0 {
+            provider.tokens as f64 / overview.total_tokens as f64 * 100.0
+        } else {
+            0.0
+        };
+    }
+
+    let mut total_costs = queries::CostAccumulator::default();
+    for provider in &overview.providers {
+        total_costs.add(provider.cost_detail.clone());
+    }
+    overview.total_cost_detail = total_costs.finish();
 }
 
 fn claude_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
@@ -729,5 +814,84 @@ fn pi_snapshot(conn: &rusqlite::Connection) -> ProviderUsageSnapshot {
         extra_windows: Vec::new(),
         local_details: local,
         error: None,
+    }
+}
+
+#[cfg(test)]
+mod cursor_overview_tests {
+    use super::*;
+
+    #[test]
+    fn merge_adds_cursor_tokens_for_matching_window_only() {
+        let previous = {
+            let mut cache = PROVIDER_CACHE.lock().unwrap();
+            let previous = cache.cursor.cache.take();
+            cache.cursor.cache = Some(ProviderCacheData::Cursor(providers::CursorProviderData {
+                summary: Vec::new(),
+                extra: Vec::new(),
+                window_24h: providers::CursorWindowAggregate::default(),
+                window_7d: providers::CursorWindowAggregate {
+                    tokens_input: 10,
+                    tokens_output: 5,
+                    tokens_cache_read: 20,
+                    tokens_cache_write: 0,
+                    cost: Some(1.5),
+                    models: vec![providers::CursorModelAggregate {
+                        name: "grok".to_string(),
+                        tokens_input: 10,
+                        tokens_output: 5,
+                        tokens_cache_read: 20,
+                        tokens_cache_write: 0,
+                        cost: Some(1.5),
+                    }],
+                },
+                window_30d: providers::CursorWindowAggregate::default(),
+            }));
+            previous
+        };
+
+        let mut overview = UsageOverview {
+            window: "7d".to_string(),
+            total_tokens: 100,
+            total_cost: Some(2.0),
+            total_cost_detail: UsageCost {
+                amount: Some(2.0),
+                kind: "estimated".to_string(),
+                basis: "local-pricing".to_string(),
+                confidence: "estimated".to_string(),
+            },
+            active_projects: 1,
+            active_sessions: 1,
+            providers: vec![UsageOverviewProvider {
+                provider: "claude".to_string(),
+                tokens: 100,
+                tokens_input: 80,
+                tokens_output: 20,
+                tokens_cache_read: 0,
+                tokens_cache_write: 0,
+                tokens_thoughts: 0,
+                cost: Some(2.0),
+                cost_detail: UsageCost {
+                    amount: Some(2.0),
+                    kind: "estimated".to_string(),
+                    basis: "local-pricing".to_string(),
+                    confidence: "estimated".to_string(),
+                },
+                share_percent: 100.0,
+                trend: vec![1, 2],
+            }],
+            trend: Vec::new(),
+            top_models: Vec::new(),
+            top_projects: Vec::new(),
+        };
+        merge_cursor_overview(&mut overview);
+
+        let cursor = overview.providers.iter().find(|provider| provider.provider == "cursor").unwrap();
+        assert_eq!(cursor.tokens, 35);
+        assert_eq!(overview.total_tokens, 135);
+        assert_eq!(overview.top_models[0].label, "grok");
+        assert_eq!(overview.total_cost_detail.kind, "mixed");
+
+        PROVIDER_CACHE.lock().unwrap().cursor.cache = previous;
     }
 }

--- a/src-tauri/src/usage/providers.rs
+++ b/src-tauri/src/usage/providers.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use super::helpers::{home_join, run_command};
-use super::types::UsageWindowSnapshot;
+use super::helpers::{home_join, now_epoch_seconds, run_command};
+use super::types::{LocalUsageDetails, UsageCost, UsageNamedTokens, UsageWindowSnapshot};
 
 /// Fetch Codex rate limit windows from ChatGPT API.
 pub fn codex_provider_windows() -> Result<Vec<UsageWindowSnapshot>, String> {
@@ -61,11 +61,74 @@ fn codex_rate_window(value: &Value) -> Option<UsageWindowSnapshot> {
     Some(percent_window("codex", label, value))
 }
 
-/// Fetch the same billing-period utilization displayed by Cursor CLI's `/usage`.
-pub fn cursor_provider_windows() -> Result<(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>), String> {
+#[derive(Debug, Clone, Default)]
+pub struct CursorModelAggregate {
+    pub name: String,
+    pub tokens_input: u64,
+    pub tokens_output: u64,
+    pub tokens_cache_read: u64,
+    pub tokens_cache_write: u64,
+    pub cost: Option<f64>,
+}
+
+impl CursorModelAggregate {
+    pub(super) fn tokens_total(&self) -> u64 {
+        self.tokens_input
+            .saturating_add(self.tokens_output)
+            .saturating_add(self.tokens_cache_read)
+            .saturating_add(self.tokens_cache_write)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CursorWindowAggregate {
+    pub tokens_input: u64,
+    pub tokens_output: u64,
+    pub tokens_cache_read: u64,
+    pub tokens_cache_write: u64,
+    pub cost: Option<f64>,
+    pub models: Vec<CursorModelAggregate>,
+}
+
+impl CursorWindowAggregate {
+    pub(super) fn tokens_total(&self) -> u64 {
+        self.tokens_input
+            .saturating_add(self.tokens_output)
+            .saturating_add(self.tokens_cache_read)
+            .saturating_add(self.tokens_cache_write)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tokens_total() == 0 && self.models.is_empty() && self.cost.is_none()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CursorProviderData {
+    pub summary: Vec<UsageWindowSnapshot>,
+    pub extra: Vec<UsageWindowSnapshot>,
+    pub window_24h: CursorWindowAggregate,
+    pub window_7d: CursorWindowAggregate,
+    pub window_30d: CursorWindowAggregate,
+}
+
+/// Fetch billing-period utilization plus token/cost aggregates for 24h / 7d / 30d.
+pub fn cursor_provider_data() -> Result<CursorProviderData, String> {
     let token = cursor_access_token()?;
+    let (summary, extra) = cursor_period_usage(&token)?;
+    Ok(CursorProviderData {
+        summary,
+        extra,
+        window_24h: cursor_window_aggregate(&token, 86_400).unwrap_or_default(),
+        window_7d: cursor_window_aggregate(&token, 604_800).unwrap_or_default(),
+        window_30d: cursor_window_aggregate(&token, 2_592_000).unwrap_or_default(),
+    })
+}
+
+fn cursor_dashboard_post(token: &str, method: &str, body: &str) -> Result<String, String> {
     let authorization = format!("Authorization: Bearer {token}");
-    let body = run_command(
+    let url = format!("https://api2.cursor.sh/aiserver.v1.DashboardService/{method}");
+    run_command(
         "curl",
         &[
             "-sS", "--max-time", "10", "-X", "POST",
@@ -74,11 +137,21 @@ pub fn cursor_provider_windows() -> Result<(Vec<UsageWindowSnapshot>, Vec<UsageW
             "-H", "Connect-Protocol-Version: 1",
             "-H", "x-cursor-client-type: cli",
             "-H", "x-cursor-client-version: cli-shep",
-            "-d", "{}",
-            "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+            "-d", body,
+            &url,
         ],
-    )?;
-    cursor_parse_period_usage(&body)
+    )
+}
+
+fn cursor_period_usage(token: &str) -> Result<(Vec<UsageWindowSnapshot>, Vec<UsageWindowSnapshot>), String> {
+    cursor_parse_period_usage(&cursor_dashboard_post(token, "GetCurrentPeriodUsage", "{}")?)
+}
+
+fn cursor_window_aggregate(token: &str, window_secs: u64) -> Result<CursorWindowAggregate, String> {
+    let end_ms = now_epoch_seconds().saturating_mul(1000);
+    let start_ms = end_ms.saturating_sub(window_secs.saturating_mul(1000));
+    let body = format!(r#"{{"startDate":"{start_ms}","endDate":"{end_ms}"}}"#);
+    cursor_parse_aggregated_usage(&cursor_dashboard_post(token, "GetAggregatedUsageEvents", &body)?)
 }
 
 fn cursor_access_token() -> Result<String, String> {
@@ -182,9 +255,142 @@ fn cursor_parse_period_usage(body: &str) -> Result<(Vec<UsageWindowSnapshot>, Ve
     Ok((summary, extra))
 }
 
+fn cursor_parse_aggregated_usage(body: &str) -> Result<CursorWindowAggregate, String> {
+    let json: Value = serde_json::from_str(body)
+        .map_err(|e| format!("Failed to parse Cursor aggregate usage: {e}"))?;
+    if let Some(code) = json.get("code") {
+        let message = json.get("message").and_then(Value::as_str).unwrap_or("request failed");
+        return Err(format!("Cursor aggregate usage API returned {code}: {message}"));
+    }
+
+    let mut models: Vec<CursorModelAggregate> = json
+        .get("aggregations")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(cursor_model_aggregate)
+        .collect();
+    models.sort_by(|a, b| b.tokens_total().cmp(&a.tokens_total()));
+
+    let tokens_input = cursor_u64(json.get("totalInputTokens"))
+        .or_else(|| Some(models.iter().map(|model| model.tokens_input).sum()));
+    let tokens_output = cursor_u64(json.get("totalOutputTokens"))
+        .or_else(|| Some(models.iter().map(|model| model.tokens_output).sum()));
+    let tokens_cache_write = cursor_u64(json.get("totalCacheWriteTokens"))
+        .or_else(|| Some(models.iter().map(|model| model.tokens_cache_write).sum()));
+    let tokens_cache_read = cursor_u64(json.get("totalCacheReadTokens"))
+        .or_else(|| Some(models.iter().map(|model| model.tokens_cache_read).sum()));
+    let cost = cursor_cents_to_usd(json.get("totalCostCents")).or_else(|| {
+        let total: f64 = models.iter().filter_map(|model| model.cost).sum();
+        (total > 0.0).then_some(total)
+    });
+
+    Ok(CursorWindowAggregate {
+        tokens_input: tokens_input.unwrap_or(0),
+        tokens_output: tokens_output.unwrap_or(0),
+        tokens_cache_read: tokens_cache_read.unwrap_or(0),
+        tokens_cache_write: tokens_cache_write.unwrap_or(0),
+        cost,
+        models,
+    })
+}
+
+fn cursor_model_aggregate(value: &Value) -> Option<CursorModelAggregate> {
+    let name = value
+        .get("modelIntent")
+        .or_else(|| value.get("model_intent"))
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())?
+        .to_string();
+    Some(CursorModelAggregate {
+        name,
+        tokens_input: cursor_u64(value.get("inputTokens").or_else(|| value.get("input_tokens"))).unwrap_or(0),
+        tokens_output: cursor_u64(value.get("outputTokens").or_else(|| value.get("output_tokens"))).unwrap_or(0),
+        tokens_cache_read: cursor_u64(value.get("cacheReadTokens").or_else(|| value.get("cache_read_tokens"))).unwrap_or(0),
+        tokens_cache_write: cursor_u64(value.get("cacheWriteTokens").or_else(|| value.get("cache_write_tokens"))).unwrap_or(0),
+        cost: cursor_cents_to_usd(value.get("totalCents").or_else(|| value.get("total_cents"))),
+    })
+}
+
+fn cursor_u64(value: Option<&Value>) -> Option<u64> {
+    cursor_number(value).map(|value| value.max(0.0).round() as u64)
+}
+
+fn cursor_cents_to_usd(value: Option<&Value>) -> Option<f64> {
+    cursor_number(value).map(|cents| cents / 100.0)
+}
+
+fn cursor_included_cost(amount: Option<f64>) -> UsageCost {
+    UsageCost {
+        amount,
+        kind: "included".to_string(),
+        basis: "subscription".to_string(),
+        confidence: "official".to_string(),
+    }
+}
+
+pub fn cursor_local_details(data: &CursorProviderData) -> Option<LocalUsageDetails> {
+    if data.window_24h.is_empty() && data.window_7d.is_empty() && data.window_30d.is_empty() {
+        return None;
+    }
+    let primary = &data.window_30d;
+    let has_type_breakdown = primary.tokens_input > 0 || primary.tokens_output > 0;
+    let cost_7d = data.window_7d.cost;
+    let cost_30d = primary.cost;
+    Some(LocalUsageDetails {
+        source_type: "local".to_string(),
+        confidence: "official".to_string(),
+        tokens_total: primary.tokens_total(),
+        tokens_input: has_type_breakdown.then_some(primary.tokens_input),
+        tokens_output: has_type_breakdown.then_some(primary.tokens_output),
+        tokens_cached: has_type_breakdown.then_some(
+            primary.tokens_cache_read.saturating_add(primary.tokens_cache_write),
+        ),
+        tokens_thoughts: None,
+        tokens_5h: 0,
+        tokens_7d: data.window_7d.tokens_total(),
+        tokens_30d: primary.tokens_total(),
+        cost_total: cost_30d,
+        cost_total_detail: cursor_included_cost(cost_30d),
+        cost_month: cost_30d,
+        cost_month_detail: cursor_included_cost(cost_30d),
+        cost_5h: None,
+        cost_5h_detail: cursor_included_cost(None),
+        cost_7d,
+        cost_7d_detail: cursor_included_cost(cost_7d),
+        cost_30d,
+        cost_30d_detail: cursor_included_cost(cost_30d),
+        top_models: primary
+            .models
+            .iter()
+            .map(|model| UsageNamedTokens {
+                name: model.name.clone(),
+                tokens: model.tokens_total(),
+                cost: model.cost,
+                cost_detail: cursor_included_cost(model.cost),
+            })
+            .collect(),
+        top_tasks: Vec::new(),
+        top_projects: Vec::new(),
+    })
+}
+
+pub fn cursor_window_for_overview<'a>(data: &'a CursorProviderData, window: &str) -> Option<&'a CursorWindowAggregate> {
+    let aggregate = match window {
+        "24h" => &data.window_24h,
+        "7d" => &data.window_7d,
+        "30d" => &data.window_30d,
+        _ => return None,
+    };
+    (!aggregate.is_empty()).then_some(aggregate)
+}
+
 #[cfg(test)]
 mod cursor_tests {
-    use super::cursor_parse_period_usage;
+    use super::{
+        cursor_local_details, cursor_parse_aggregated_usage, cursor_parse_period_usage,
+        cursor_window_for_overview, CursorModelAggregate, CursorProviderData, CursorWindowAggregate,
+    };
 
     #[test]
     fn maps_cursor_billing_percentages_and_millisecond_reset() {
@@ -207,6 +413,80 @@ mod cursor_tests {
         let error = cursor_parse_period_usage(r#"{"code":"unauthenticated","message":"not logged in"}"#)
             .expect_err("auth error");
         assert!(error.contains("cursor-agent login"));
+    }
+
+    #[test]
+    fn maps_cursor_aggregate_tokens_cost_and_models() {
+        let aggregate = cursor_parse_aggregated_usage(r#"{
+            "aggregations": [
+                {
+                    "modelIntent": "cursor-grok-4.6-high-fast",
+                    "inputTokens": "833991",
+                    "outputTokens": "130654",
+                    "cacheReadTokens": "10320640",
+                    "totalCents": 760.4595,
+                    "tier": 2
+                },
+                {
+                    "modelIntent": "default",
+                    "inputTokens": "16201",
+                    "outputTokens": "517",
+                    "cacheReadTokens": "16896",
+                    "totalCents": 2.757725,
+                    "tier": 2
+                }
+            ],
+            "totalInputTokens": "850192",
+            "totalOutputTokens": "131171",
+            "totalCacheReadTokens": "10337536",
+            "totalCostCents": 763.217225
+        }"#).expect("aggregate");
+        assert_eq!(aggregate.tokens_input, 850192);
+        assert_eq!(aggregate.tokens_output, 131171);
+        assert_eq!(aggregate.tokens_cache_read, 10337536);
+        assert!((aggregate.cost.unwrap() - 7.63217225).abs() < 0.0001);
+        assert_eq!(aggregate.models[0].name, "cursor-grok-4.6-high-fast");
+        assert_eq!(aggregate.models[1].name, "default");
+        assert_eq!(aggregate.models[0].tokens_total(), 833991 + 130654 + 10320640);
+    }
+
+    #[test]
+    fn local_details_use_30d_totals_and_7d_window() {
+        let data = CursorProviderData {
+            summary: Vec::new(),
+            extra: Vec::new(),
+            window_24h: CursorWindowAggregate::default(),
+            window_7d: CursorWindowAggregate {
+                tokens_input: 10,
+                tokens_output: 5,
+                tokens_cache_read: 20,
+                tokens_cache_write: 0,
+                cost: Some(1.25),
+                models: Vec::new(),
+            },
+            window_30d: CursorWindowAggregate {
+                tokens_input: 100,
+                tokens_output: 50,
+                tokens_cache_read: 200,
+                tokens_cache_write: 0,
+                cost: Some(4.5),
+                models: vec![CursorModelAggregate {
+                    name: "cursor-grok-4.6-high-fast".to_string(),
+                    tokens_input: 100,
+                    tokens_output: 50,
+                    tokens_cache_read: 200,
+                    tokens_cache_write: 0,
+                    cost: Some(4.5),
+                }],
+            },
+        };
+        let details = cursor_local_details(&data).expect("details");
+        assert_eq!(details.tokens_7d, 35);
+        assert_eq!(details.tokens_30d, 350);
+        assert_eq!(details.tokens_input, Some(100));
+        assert_eq!(details.top_models[0].name, "cursor-grok-4.6-high-fast");
+        assert_eq!(cursor_window_for_overview(&data, "7d").unwrap().tokens_total(), 35);
+        assert!(cursor_window_for_overview(&data, "365d").is_none());
     }
 }
 

--- a/src-tauri/src/usage/queries.rs
+++ b/src-tauri/src/usage/queries.rs
@@ -187,7 +187,7 @@ fn resolved_cost_detail(
 }
 
 #[derive(Clone, Default)]
-struct CostAccumulator {
+pub(super) struct CostAccumulator {
     amount: f64,
     has_cost: bool,
     kind: Option<String>,
@@ -197,7 +197,7 @@ struct CostAccumulator {
 }
 
 impl CostAccumulator {
-    fn add(&mut self, cost: UsageCost) {
+    pub(super) fn add(&mut self, cost: UsageCost) {
         let Some(amount) = cost.amount else {
             return;
         };
@@ -216,7 +216,7 @@ impl CostAccumulator {
         self.confidence.get_or_insert(cost.confidence);
     }
 
-    fn finish(self) -> UsageCost {
+    pub(super) fn finish(self) -> UsageCost {
         if !self.has_cost {
             return unknown_cost();
         }

--- a/src/components/usage/UsagePanel.tsx
+++ b/src/components/usage/UsagePanel.tsx
@@ -711,7 +711,8 @@ function OverviewPanel({ overview, snapshots }: { overview: UsageOverview; snaps
           <h3 className="section-label !p-0">Methodology</h3>
         </div>
         <ul className="usage-methodology">
-          <li>Usage totals and breakdowns on this screen are based on locally observed activity from this machine.</li>
+          <li>Usage totals and breakdowns on this screen are based on locally observed activity from this machine, except Cursor, which uses Cursor's billing aggregates for the selected window.</li>
+          <li>Cursor does not expose per-project or per-session usage, so it will not appear in the project list or activity heatmap.</li>
           <li>Provider percentages shown in the sidebar summary come from provider-reported usage windows when available, so they are not always directly comparable to the local totals shown here.</li>
           <li>In practice, that means the sidebar percentage and this detail view can differ because they are measuring related but not identical sources.</li>
         </ul>


### PR DESCRIPTION
## Summary
- Fetch Cursor 24h / 7d / 30d token totals, official cost, and model mix from `GetAggregatedUsageEvents` on the existing CLI usage refresh.
- Keep the subscription billing % bar from `GetCurrentPeriodUsage`; skip per-request pagination and local transcript ingest, which Cursor does not persist.
- Merge those aggregates into the usage overview provider and model lists. Project breakdown and heatmap stay empty for Cursor.

## Test plan
- [ ] Restart Shep with an authenticated `cursor-agent` login
- [ ] Confirm the Cursor billing % bar still appears in the sidebar
- [ ] Open Usage and check 24h / 7d / 30d for Cursor tokens, cost, and model rows
- [ ] Confirm Cursor is absent from project breakdown, heatmap, and the 1-year tab
- [ ] Confirm a machine without Cursor login still shows other providers


Made with [Cursor](https://cursor.com)